### PR TITLE
Feature/submission : 제출물 엔티티 정의와 컨트롤러 사전작업

### DIFF
--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionController.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionController.java
@@ -1,0 +1,33 @@
+package CoCoNut_was.domains.submission.controller;
+
+import CoCoNut_was.domains.submission.service.SubmissionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class SubmissionController {
+    private final SubmissionService submissionService;
+
+
+    // 1. 제출물 등록
+    @PostMapping("/projects/{project_id}/submissions")
+    public ResponseEntity<?> submit(@PathVariable Long project_id){ // 제출할 dto도 보내야함
+        return ResponseEntity.ok().build();
+    }
+
+    // 2. 제출물 목록 조회(한 공모전에 대한 모든 제출물 조회)
+    @GetMapping("/projects/{project_id}/submissions")
+    public ResponseEntity<?> getSubmissions(@PathVariable Long project_id){
+        return ResponseEntity.ok().build();
+    }
+
+    // 3. 제출물 수정
+    @PutMapping("/submissions/{submission_id}")
+    public ResponseEntity<?> updateSubmission(@PathVariable Long submission_id){ // 수정할 dto도 보내야함
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/CoCoNut_was/domains/submission/entity/Submission.java
+++ b/src/main/java/CoCoNut_was/domains/submission/entity/Submission.java
@@ -1,0 +1,44 @@
+package CoCoNut_was.domains.submission.entity;
+
+import CoCoNut_was.domains.project.entitiy.Project;
+import CoCoNut_was.domains.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Submission {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String description;
+
+    @Column
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private LocalDate submittedAt;
+
+    @ManyToOne
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder public Submission(String description, String imageUrl, LocalDate submittedAt, Project project, User user) {
+        this.description = description;
+        this.imageUrl = imageUrl;
+        this.submittedAt = submittedAt;
+        this.project = project;
+        this.user = user;
+    }
+}

--- a/src/main/java/CoCoNut_was/domains/submission/repository/SubmissionRepository.java
+++ b/src/main/java/CoCoNut_was/domains/submission/repository/SubmissionRepository.java
@@ -1,0 +1,9 @@
+package CoCoNut_was.domains.submission.repository;
+
+import CoCoNut_was.domains.submission.entity.Submission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SubmissionRepository extends JpaRepository<Submission, Long> {
+}

--- a/src/main/java/CoCoNut_was/domains/submission/service/SubmissionService.java
+++ b/src/main/java/CoCoNut_was/domains/submission/service/SubmissionService.java
@@ -1,0 +1,9 @@
+package CoCoNut_was.domains.submission.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SubmissionService {
+}


### PR DESCRIPTION
## 작업 개요
- 제출물(submission)에 대한 기본 엔티티 정의와, api명세서에 따라 컨트롤러에 주석을 정의하였습니다.


## 관련 이슈
- 유저와 프로젝트에 대해 1:N인지 1:1인지의 관계를 명확하게 정할 필요가 있어보입니다.