### PR TITLE
Feature/swagger : 스웨거 기본 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9' // Spring Boot 3.x용 Swagger
+
 }
 
 tasks.named('test') {

--- a/src/main/java/CoCoNut_was/domains/user/reqdto/CreateUserDto.java
+++ b/src/main/java/CoCoNut_was/domains/user/reqdto/CreateUserDto.java
@@ -2,27 +2,34 @@ package CoCoNut_was.domains.user.reqdto;
 
 import CoCoNut_was.domains.user.entity.Role;
 import CoCoNut_was.domains.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
+@Schema(description = "회원가입 요청 API")
 public class CreateUserDto {
+    @Schema(description = "사용자 이메일", example = "likelion13@gmail.com")
     @Email(message = "이메일 형식을 맞춰주세요.")
     @NotBlank(message = "이메일은 필수 입력입니다.")
     private String email;
 
+    @Schema(description = "사용자 이름", example = "홍길동")
     @NotBlank(message = "이름은 필수 입력입니다.")
     private String name;
 
+    @Schema(description = "사용자 닉네임", example = "열정있는 아기사자")
     @NotBlank(message = "닉네임은 필수 입력입니다.")
     @Size(max = 10, message = "닉네임은 최대 10글자 까지 가능합니다.")
     private String nickname;
 
+    @Schema(description = "비밀번호", example = "abcd1234")
     @NotBlank(message = "비밀번호는 필수 입력입니다.")
     private String password;
 
+    @Schema(description = "역할", example = "ROLE_USER | ROLE_BUSINESS")
     @NotBlank(message = "역할 지정은 필수 사항입니다.")
     private String role;
 

--- a/src/main/java/CoCoNut_was/domains/user/reqdto/LoginUserDto.java
+++ b/src/main/java/CoCoNut_was/domains/user/reqdto/LoginUserDto.java
@@ -1,15 +1,18 @@
 package CoCoNut_was.domains.user.reqdto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class LoginUserDto {
+    @Schema(description = "사용자 이메일", example = "likelion13@gmail.com")
     @Email(message = "이메일 형식을 맞춰주세요.")
     @NotBlank(message = "이메일은 필수 입력입니다.")
     private String email;
 
+    @Schema(description = "비밀번호", example = "abcd1234")
     @NotBlank(message = "비밀번호는 필수 입력입니다.")
     private String password;
 }

--- a/src/main/java/CoCoNut_was/security/SecurityConfig.java
+++ b/src/main/java/CoCoNut_was/security/SecurityConfig.java
@@ -41,6 +41,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/users/sign-up").permitAll()
                         .requestMatchers("/api/v1/users/login").permitAll()
+                        .requestMatchers("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**",
+                                "/webjars/**", "/error").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/CoCoNut_was/swagger/SwaggerConfig.java
+++ b/src/main/java/CoCoNut_was/swagger/SwaggerConfig.java
@@ -1,0 +1,23 @@
+package CoCoNut_was.swagger;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(info = @Info(title = "CoCoNut API", description = "CoCoNut API 명세서", version = "v1"))
+public class SwaggerConfig {
+
+    @Bean
+    public GroupedOpenApi openApi() {
+        String[] paths = {"/**"};
+
+        return GroupedOpenApi.builder()
+                .group("CoCoNut API")
+                .pathsToMatch(paths)
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 작업 개요
- 프론트엔드 요구사항에 따라 스웨거 기본 세팅을 하였습니다.

## 변경 사항
- Swagger 의존성 추가
- SwaggerConfig 설정
- SecurityConfig에서 Swagger 비인증 접속 허용
- User 요청 DTO에 Swagger 명세 작성(테스트)

## 관련 이슈
- 스웨거와 스프링부트의 버전 호환성이 적절한지 모르겠습니다. 이후에 문제가 생길 우려가 있으니 예의주시 바랍니다.