### PR TITLE
Feature/swagger getuser : 회원 상세조회 명세, 인증/인가 커스텀 예외처리, Swagger JWT 액세스 토큰 입력

### DIFF
--- a/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
+++ b/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
@@ -9,7 +9,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jdk.jfr.ContentType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "User API", description = "유저 관련 API")
@@ -55,6 +57,44 @@ public interface UserApi {
     ResponseEntity<?> signUp(
             @Parameter(description = "회원가입 정보")
             @Valid @RequestBody CreateUserDto dto
+    );
+
+
+    @Operation(summary = "회원 상세조회", description = "조회 시도")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "email": "<email>",
+                                        "name": "<name>",
+                                        "nickname": "<nickname>",
+                                        "role": "ROLE_USER | ROLE_BUSINESS"
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "ID가 존재하지 않음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 404,
+                                        "message": "해당 유저를 찾을 수 없습니다."
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "중복으로 인한 회원가입 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "이메일 중복", value = """
+                                    {
+                                        "status" : 403,
+                                        "message" : "액세스 토큰 인증 실패"
+                                    }
+                                    """),
+                    })) //임시로 작성
+    })
+    ResponseEntity<?> getUser(
+            @Parameter(description = "유저 고유 ID")
+            @PathVariable Long user_id
     );
 
 

--- a/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
+++ b/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
@@ -82,12 +82,12 @@ public interface UserApi {
                                     }
                                     """)
                     })),
-            @ApiResponse(responseCode = "403", description = "중복으로 인한 회원가입 실패",
+            @ApiResponse(responseCode = "401", description = "액세스 토큰을 기입하지 않음",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(name = "이메일 중복", value = """
                                     {
-                                        "status" : 403,
-                                        "message" : "액세스 토큰 인증 실패"
+                                        "status" : 401,
+                                        "message" : "액세스 토큰 인증이 필요합니다."
                                     }
                                     """),
                     })) //임시로 작성

--- a/src/main/java/CoCoNut_was/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/CoCoNut_was/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,30 @@
+package CoCoNut_was.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    // 403 반환에 대한 커스텀 예외처리
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorDto errorDto = new ErrorDto(HttpStatus.FORBIDDEN.value(), "접근 권한이 없습니다.");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.getWriter().write(objectMapper.writeValueAsString(errorDto));
+    }
+}

--- a/src/main/java/CoCoNut_was/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/CoCoNut_was/exception/CustomAuthenticationEntryPoint.java
@@ -21,7 +21,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
 
-        ErrorDto errorDto = new ErrorDto(HttpStatus.UNAUTHORIZED.value(), "인증이 필요합니다.");
+        ErrorDto errorDto = new ErrorDto(HttpStatus.UNAUTHORIZED.value(), "액세스 토큰 인증이 필요합니다.");
 
         ObjectMapper objectMapper = new ObjectMapper();
         response.getWriter().write(objectMapper.writeValueAsString(errorDto));

--- a/src/main/java/CoCoNut_was/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/CoCoNut_was/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,29 @@
+package CoCoNut_was.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorDto errorDto = new ErrorDto(HttpStatus.UNAUTHORIZED.value(), "인증이 필요합니다.");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.getWriter().write(objectMapper.writeValueAsString(errorDto));
+    }
+}

--- a/src/main/java/CoCoNut_was/security/SecurityConfig.java
+++ b/src/main/java/CoCoNut_was/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package CoCoNut_was.security;
 
+import CoCoNut_was.exception.CustomAccessDeniedHandler;
+import CoCoNut_was.exception.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,6 +21,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     PasswordEncoder passwordEncoder() {
@@ -44,6 +48,10 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**",
                                 "/webjars/**", "/error").permitAll()
                         .anyRequest().authenticated()
+                )
+                .exceptionHandling(exceptions -> exceptions
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler)
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/CoCoNut_was/swagger/SwaggerConfig.java
+++ b/src/main/java/CoCoNut_was/swagger/SwaggerConfig.java
@@ -2,12 +2,27 @@ package CoCoNut_was.swagger;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@OpenAPIDefinition(info = @Info(title = "CoCoNut API", description = "CoCoNut API 명세서", version = "v1"))
+@OpenAPIDefinition(
+        info = @Info(title = "CoCoNut API", description = "CoCoNut API 명세서", version = "v1"),
+        security = @SecurityRequirement(name = "bearerAuth")
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        in = SecuritySchemeIn.HEADER,
+        paramName = "Authorization"
+)
 public class SwaggerConfig {
 
     @Bean
@@ -19,5 +34,4 @@ public class SwaggerConfig {
                 .pathsToMatch(paths)
                 .build();
     }
-
 }


### PR DESCRIPTION
## 작업 개요
- 회원 상세조회를 명세하였습니다.
- 인증/인가 커스텀 예외처리를 추가하였습니다.
- Swagger에서 JWT 인증이 가능하도록 추가하였습니다.

## 변경 사항
- 기본 설정인 403 에러에서 401 에러로 변경되었습니다.
- 커스텀 예외처리 클래스 2개가 추가되었습니다.
- SecurityConfig에 커스텀 예외처리 2개를 적용하였습니다.
- SwaggerConfig에 Bearer JWT 인증이 가능하도록 코드를 추가하였습니다.

## 관련 이슈
- Postman의 방식인 "Bearer <토큰>" 입력과 다르게 Swagger에서는 "<토큰>" 입력 후 인증하는 방식인 점에 주의 바랍니다.