### PR TITLE
Feature/swagger logout

### DIFF
--- a/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
+++ b/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
@@ -147,9 +147,9 @@ public interface UserApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                     {
-                                        "accessToken": "<accessToken>",
-                                        "userId": <userID>,
-                                        "email": "<email>"
+                                        "accessToken" : "<accessToken>",
+                                        "userId" : "<userId>",
+                                        "email" : "<email>"
                                     }
                                     """)
                     })),

--- a/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
+++ b/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import jdk.jfr.ContentType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -92,12 +91,12 @@ public interface UserApi {
                                     }
                                     """)
                     })),
-            @ApiResponse(responseCode = "401", description = "액세스 토큰을 기입하지 않음",
+            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                     {
                                         "status" : 401,
-                                        "message" : "액세스 토큰 인증이 필요합니다."
+                                        "message" : "액세스 토큰이 유효하지 않습니다."
                                     }
                                     """),
                     }))
@@ -122,10 +121,10 @@ public interface UserApi {
                     })),
             @ApiResponse(responseCode = "401", description = "인증 실패",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name = "액세스 토큰 없음", value = """
+                            @ExampleObject(name = "액세스 토큰 없음 / 만료", value = """
                                     {
                                         "status" : 401,
-                                        "message" : "액세스 토큰 인증이 필요합니다."
+                                        "message" : "액세스 토큰이 유효하지 않습니다."
                                     }
                                     """),
                             @ExampleObject(name = "비밀번호 불일치", value = """
@@ -169,5 +168,21 @@ public interface UserApi {
             @Valid @RequestBody LoginUserDto dto,
             HttpServletResponse res
     );
+
+
+    @Operation(summary = "로그아웃", description = "로그아웃 시도")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status" : 401,
+                                        "message" : "액세스 토큰이 유효하지 않습니다."
+                                    }
+                                    """),
+                    }))
+    })
+    ResponseEntity<?> logout(HttpServletResponse res);
 
 }

--- a/src/main/java/CoCoNut_was/domains/user/controller/UserController.java
+++ b/src/main/java/CoCoNut_was/domains/user/controller/UserController.java
@@ -51,7 +51,8 @@ public class UserController implements UserApi {
         return ResponseEntity.ok(tokenResDto);
     }
 
-    // 5. 로그아웃 : 리프레쉬 토큰만 제거, 액세스 토큰은 프론트엔드에서 제거해줘야함
+    // 5. 로그아웃 : 단순 토큰인증, 액세스 토큰은 프론트엔드에서 제거해줘야함
+    @Override
     @PostMapping("/logout")
     public ResponseEntity<?> logout(HttpServletResponse res) {
         userService.logout(res);


### PR DESCRIPTION
## 작업 개요
- 로그아웃 Swagger 명세 입니다.

## 변경 사항
- 로그아웃 Swagger 명세를 추가했습니다.
- Swagger에 로그인 성공 예시 응답 부분이 깨진 오류가 발견되어 수정하였습니다.

## 관련 이슈
- 로그아웃 자체는 그냥 토큰 인증이랑 큰 차이가 없어서 실제로는 프론트엔드 측에서 그냥 토큰을 삭제하는 방향으로 해야할 것 같습니다.