### PR TITLE
fix : CI/CD workflow 메모리 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,8 @@ jobs:
         run: chmod +x ./gradlew # 3. gradlew 파일에 실행 권한을 부여합니다.
 
       - name: Build with Gradle
+        env: 
+          GRADLE_OPTS: -Xmx2048m # Gradle이 사용하는 최대 메모리를 2GB로 제한합니다.
         run: ./gradlew build -x test # 4. Gradle로 프로젝트를 빌드합니다. (테스트는 제외)
 
       - name: Deploy to EC2


### PR DESCRIPTION
## 작업 개요
- CI/CD workflow 메모리를 변경하는 작업을 진행하였습니다.

## 변경 사항
- Gradle이 사용하는 최대 메모리를 2GB로 제한하였습니다.

## 관련 이슈
- #28