### PR TITLE
Fix/user

### DIFF
--- a/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
+++ b/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
@@ -12,6 +12,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -59,86 +61,54 @@ public interface UserApi {
             @Parameter(description = "회원가입 정보")
             @Valid @RequestBody CreateUserDto dto
     );
-//
-//
-//    @Operation(summary = "회원 상세조회", description = "조회 시도")
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200", description = "조회 성공",
-//                    content = @Content(mediaType = "application/json", examples = {
-//                            @ExampleObject(value = """
-//                                    {
-//                                        "email": "<email>",
-//                                        "name": "<name>",
-//                                        "nickname": "<nickname>",
-//                                        "role": "ROLE_USER | ROLE_BUSINESS"
-//                                    }
-//                                    """)
-//                    })),
-//            @ApiResponse(responseCode = "400", description = "입력 누락 및 형식 비일치",
-//                    content = @Content(mediaType = "application/json", examples = {
-//                            @ExampleObject(name = "필드 누락", value = """
-//                                    {
-//                                        "<field>" : "<field>는 필수 입력입니다."
-//                                    }
-//                                    """)
-//                    })),
-//            @ApiResponse(responseCode = "404", description = "ID가 존재하지 않음",
-//                    content = @Content(mediaType = "application/json", examples = {
-//                            @ExampleObject(value = """
-//                                    {
-//                                        "status": 404,
-//                                        "message": "해당 유저를 찾을 수 없습니다."
-//                                    }
-//                                    """)
-//                    })),
-//            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
-//                    content = @Content(mediaType = "application/json", examples = {
-//                            @ExampleObject(value = """
-//                                    {
-//                                        "status" : 401,
-//                                        "message" : "액세스 토큰이 유효하지 않습니다."
-//                                    }
-//                                    """),
-//                    }))
-//    })
-//    ResponseEntity<?> getUser(
-//            @Parameter(description = "유저 고유 ID")
-//            @PathVariable Long user_id
-//    );
-//
 
-//    @Operation(summary = "회원탈퇴(삭제)", description = "탈퇴(삭제) 시도")
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200", description = "삭제 성공"),
-//            @ApiResponse(responseCode = "404", description = "ID가 존재하지 않음",
-//                    content = @Content(mediaType = "application/json", examples = {
-//                            @ExampleObject(value = """
-//                                    {
-//                                        "status": 404,
-//                                        "message": "해당 유저를 찾을 수 없습니다."
-//                                    }
-//                                    """)
-//                    })),
-//            @ApiResponse(responseCode = "401", description = "인증 실패",
-//                    content = @Content(mediaType = "application/json", examples = {
-//                            @ExampleObject(name = "액세스 토큰 없음 / 만료", value = """
-//                                    {
-//                                        "status" : 401,
-//                                        "message" : "액세스 토큰이 유효하지 않습니다."
-//                                    }
-//                                    """),
-//                            @ExampleObject(name = "비밀번호 불일치", value = """
-//                                    {
-//                                        "status" : 401,
-//                                        "message" : "비밀번호가 일치하지 않습니다."
-//                                    }
-//                                    """)
-//                    }))
-//    })
-//    ResponseEntity<?> deleteUser(
-//            @Parameter(description = "유저 고유 ID")
-//            @PathVariable Long user_id
-//    );
+
+    @Operation(summary = "내 정보 조회", description = "조회 시도")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "email": "<email>",
+                                        "name": "<name>",
+                                        "nickname": "<nickname>",
+                                        "role": "ROLE_USER | ROLE_BUSINESS"
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status" : 401,
+                                        "message" : "토큰이 없거나 만료되었습니다."
+                                    }
+                                    """),
+                    }))
+    })
+    ResponseEntity<?> me(
+            @Parameter(description = "JWT 토큰기반 유저 조회")
+            @AuthenticationPrincipal UserDetails userDetails
+    );
+
+
+    @Operation(summary = "회원탈퇴(삭제)", description = "탈퇴(삭제) 시도")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status" : 401,
+                                        "message" : "토큰이 없거나 만료되었습니다."
+                                    }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> deleteUser(
+            @Parameter(description = "JWT 토큰기반 유저 탈퇴")
+            @AuthenticationPrincipal UserDetails userDetails
+    );
 
 
     @Operation(summary = "로그인", description = "로그인 시도")
@@ -153,12 +123,18 @@ public interface UserApi {
                                     }
                                     """)
                     })),
-            @ApiResponse(responseCode = "404", description = "ID가 존재하지 않음",
+            @ApiResponse(responseCode = "401", description = "인증 실패",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(value = """
+                            @ExampleObject(name = "액세스 토큰 없음 / 만료", value = """
                                     {
-                                        "status": 404,
-                                        "message": "해당 유저를 찾을 수 없습니다."
+                                        "status" : 401,
+                                        "message" : "토큰이 없거나 만료되었습니다."
+                                    }
+                                    """),
+                            @ExampleObject(name = "비밀번호 불일치", value = """
+                                    {
+                                        "status" : 401,
+                                        "message" : "비밀번호가 일치하지 않습니다."
                                     }
                                     """)
                     }))

--- a/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
+++ b/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
@@ -123,15 +123,18 @@ public interface UserApi {
                                     }
                                     """)
                     })),
-            @ApiResponse(responseCode = "401", description = "인증 실패",
+            @ApiResponse(responseCode = "404", description = "이메일이 존재하지 않음",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name = "액세스 토큰 없음 / 만료", value = """
+                            @ExampleObject(value = """
                                     {
-                                        "status" : 401,
-                                        "message" : "토큰이 없거나 만료되었습니다."
+                                        "status": 404,
+                                        "message": "해당 유저를 찾을 수 없습니다."
                                     }
-                                    """),
-                            @ExampleObject(name = "비밀번호 불일치", value = """
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "401", description = "비밀번호 불일치",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
                                     {
                                         "status" : 401,
                                         "message" : "비밀번호가 일치하지 않습니다."
@@ -154,7 +157,7 @@ public interface UserApi {
                             @ExampleObject(value = """
                                     {
                                         "status" : 401,
-                                        "message" : "액세스 토큰이 유효하지 않습니다."
+                                        "message" : "토큰이 없거나 만료되었습니다."
                                     }
                                     """),
                     }))

--- a/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
+++ b/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
@@ -59,53 +59,53 @@ public interface UserApi {
             @Parameter(description = "회원가입 정보")
             @Valid @RequestBody CreateUserDto dto
     );
-
-
-    @Operation(summary = "회원 상세조회", description = "조회 시도")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공",
-                    content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(value = """
-                                    {
-                                        "email": "<email>",
-                                        "name": "<name>",
-                                        "nickname": "<nickname>",
-                                        "role": "ROLE_USER | ROLE_BUSINESS"
-                                    }
-                                    """)
-                    })),
-            @ApiResponse(responseCode = "400", description = "입력 누락 및 형식 비일치",
-                    content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name = "필드 누락", value = """
-                                    {
-                                        "<field>" : "<field>는 필수 입력입니다."
-                                    }
-                                    """)
-                    })),
-            @ApiResponse(responseCode = "404", description = "ID가 존재하지 않음",
-                    content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(value = """
-                                    {
-                                        "status": 404,
-                                        "message": "해당 유저를 찾을 수 없습니다."
-                                    }
-                                    """)
-                    })),
-            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
-                    content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(value = """
-                                    {
-                                        "status" : 401,
-                                        "message" : "액세스 토큰이 유효하지 않습니다."
-                                    }
-                                    """),
-                    }))
-    })
-    ResponseEntity<?> getUser(
-            @Parameter(description = "유저 고유 ID")
-            @PathVariable Long user_id
-    );
-
+//
+//
+//    @Operation(summary = "회원 상세조회", description = "조회 시도")
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200", description = "조회 성공",
+//                    content = @Content(mediaType = "application/json", examples = {
+//                            @ExampleObject(value = """
+//                                    {
+//                                        "email": "<email>",
+//                                        "name": "<name>",
+//                                        "nickname": "<nickname>",
+//                                        "role": "ROLE_USER | ROLE_BUSINESS"
+//                                    }
+//                                    """)
+//                    })),
+//            @ApiResponse(responseCode = "400", description = "입력 누락 및 형식 비일치",
+//                    content = @Content(mediaType = "application/json", examples = {
+//                            @ExampleObject(name = "필드 누락", value = """
+//                                    {
+//                                        "<field>" : "<field>는 필수 입력입니다."
+//                                    }
+//                                    """)
+//                    })),
+//            @ApiResponse(responseCode = "404", description = "ID가 존재하지 않음",
+//                    content = @Content(mediaType = "application/json", examples = {
+//                            @ExampleObject(value = """
+//                                    {
+//                                        "status": 404,
+//                                        "message": "해당 유저를 찾을 수 없습니다."
+//                                    }
+//                                    """)
+//                    })),
+//            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
+//                    content = @Content(mediaType = "application/json", examples = {
+//                            @ExampleObject(value = """
+//                                    {
+//                                        "status" : 401,
+//                                        "message" : "액세스 토큰이 유효하지 않습니다."
+//                                    }
+//                                    """),
+//                    }))
+//    })
+//    ResponseEntity<?> getUser(
+//            @Parameter(description = "유저 고유 ID")
+//            @PathVariable Long user_id
+//    );
+//
 
 //    @Operation(summary = "회원탈퇴(삭제)", description = "탈퇴(삭제) 시도")
 //    @ApiResponses({

--- a/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
+++ b/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
@@ -107,38 +107,38 @@ public interface UserApi {
     );
 
 
-    @Operation(summary = "회원탈퇴(삭제)", description = "탈퇴(삭제) 시도")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "삭제 성공"),
-            @ApiResponse(responseCode = "404", description = "ID가 존재하지 않음",
-                    content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(value = """
-                                    {
-                                        "status": 404,
-                                        "message": "해당 유저를 찾을 수 없습니다."
-                                    }
-                                    """)
-                    })),
-            @ApiResponse(responseCode = "401", description = "인증 실패",
-                    content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name = "액세스 토큰 없음 / 만료", value = """
-                                    {
-                                        "status" : 401,
-                                        "message" : "액세스 토큰이 유효하지 않습니다."
-                                    }
-                                    """),
-                            @ExampleObject(name = "비밀번호 불일치", value = """
-                                    {
-                                        "status" : 401,
-                                        "message" : "비밀번호가 일치하지 않습니다."
-                                    }
-                                    """)
-                    }))
-    })
-    ResponseEntity<?> deleteUser(
-            @Parameter(description = "유저 고유 ID")
-            @PathVariable Long user_id
-    );
+//    @Operation(summary = "회원탈퇴(삭제)", description = "탈퇴(삭제) 시도")
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+//            @ApiResponse(responseCode = "404", description = "ID가 존재하지 않음",
+//                    content = @Content(mediaType = "application/json", examples = {
+//                            @ExampleObject(value = """
+//                                    {
+//                                        "status": 404,
+//                                        "message": "해당 유저를 찾을 수 없습니다."
+//                                    }
+//                                    """)
+//                    })),
+//            @ApiResponse(responseCode = "401", description = "인증 실패",
+//                    content = @Content(mediaType = "application/json", examples = {
+//                            @ExampleObject(name = "액세스 토큰 없음 / 만료", value = """
+//                                    {
+//                                        "status" : 401,
+//                                        "message" : "액세스 토큰이 유효하지 않습니다."
+//                                    }
+//                                    """),
+//                            @ExampleObject(name = "비밀번호 불일치", value = """
+//                                    {
+//                                        "status" : 401,
+//                                        "message" : "비밀번호가 일치하지 않습니다."
+//                                    }
+//                                    """)
+//                    }))
+//    })
+//    ResponseEntity<?> deleteUser(
+//            @Parameter(description = "유저 고유 ID")
+//            @PathVariable Long user_id
+//    );
 
 
     @Operation(summary = "로그인", description = "로그인 시도")

--- a/src/main/java/CoCoNut_was/domains/user/controller/UserController.java
+++ b/src/main/java/CoCoNut_was/domains/user/controller/UserController.java
@@ -12,6 +12,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -42,11 +44,11 @@ public class UserController implements UserApi {
     }
 
     // 3. 회원탈퇴(삭제)
-    @Override
-    @DeleteMapping("/{user_id}")
-    public ResponseEntity<?> deleteUser(@PathVariable Long user_id){
-        userService.deleteUser(user_id);
-        return ResponseEntity.ok().build();
+    @DeleteMapping
+    public ResponseEntity<String> deleteUser(
+            @AuthenticationPrincipal UserDetails userDetails) { // (1)
+        userService.deleteUser(userDetails);
+        return ResponseEntity.ok("회원탈퇴가 성공적으로 처리되었습니다.");
     }
 
     // 4. 로그인

--- a/src/main/java/CoCoNut_was/domains/user/controller/UserController.java
+++ b/src/main/java/CoCoNut_was/domains/user/controller/UserController.java
@@ -1,9 +1,5 @@
 package CoCoNut_was.domains.user.controller;
 
-/*
-회원가입(추가), 회원조회, 회원수정, 회원삭제, 로그인, 로그아웃을 다루는 컨트롤러
- */
-
 import CoCoNut_was.domains.user.reqdto.LoginUserDto;
 import CoCoNut_was.domains.user.resdto.TokenResDto;
 import CoCoNut_was.domains.user.reqdto.CreateUserDto;

--- a/src/main/java/CoCoNut_was/domains/user/controller/UserController.java
+++ b/src/main/java/CoCoNut_was/domains/user/controller/UserController.java
@@ -36,11 +36,16 @@ public class UserController implements UserApi {
         return ResponseEntity.ok().build();
     }
 
-    // 2. 회원조회
-    @Override
-    @GetMapping("/{user_id}")
-    public ResponseEntity<?> getUser(@PathVariable Long user_id){
-        return ResponseEntity.ok(userService.getUser(user_id));
+//    // 2. 회원조회 (관리자) 임시 폐기
+//    @GetMapping("/{user_id}")
+//    public ResponseEntity<?> getUser(@PathVariable Long user_id){
+//        return ResponseEntity.ok(userService.getUser(user_id));
+//    }
+
+    // 2. 마이페이지(자신 조회)
+    @GetMapping
+    public ResponseEntity<?> me(@AuthenticationPrincipal UserDetails userDetails){
+        return ResponseEntity.ok(userService.me(userDetails));
     }
 
     // 3. 회원탈퇴(삭제)

--- a/src/main/java/CoCoNut_was/domains/user/controller/UserController.java
+++ b/src/main/java/CoCoNut_was/domains/user/controller/UserController.java
@@ -16,7 +16,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,7 +41,7 @@ public class UserController implements UserApi {
 //        return ResponseEntity.ok(userService.getUser(user_id));
 //    }
 
-    // 2. 마이페이지(자신 조회)
+    // 2. 내 정보 조회(마이페이지)
     @GetMapping
     public ResponseEntity<?> me(@AuthenticationPrincipal UserDetails userDetails){
         return ResponseEntity.ok(userService.me(userDetails));
@@ -50,14 +49,12 @@ public class UserController implements UserApi {
 
     // 3. 회원탈퇴(삭제)
     @DeleteMapping
-    public ResponseEntity<String> deleteUser(
-            @AuthenticationPrincipal UserDetails userDetails) { // (1)
+    public ResponseEntity<?> deleteUser(@AuthenticationPrincipal UserDetails userDetails) {
         userService.deleteUser(userDetails);
-        return ResponseEntity.ok("회원탈퇴가 성공적으로 처리되었습니다.");
+        return ResponseEntity.ok().build();
     }
 
     // 4. 로그인
-    @Override
     @PostMapping("/login")
     public ResponseEntity<?> login(@Valid @RequestBody LoginUserDto dto, HttpServletResponse res){
         TokenResDto tokenResDto = userService.login(dto, res);
@@ -65,7 +62,6 @@ public class UserController implements UserApi {
     }
 
     // 5. 로그아웃 : 단순 토큰인증, 액세스 토큰은 프론트엔드에서 제거해줘야함
-    @Override
     @PostMapping("/logout")
     public ResponseEntity<?> logout(HttpServletResponse res) {
         userService.logout(res);

--- a/src/main/java/CoCoNut_was/domains/user/service/UserService.java
+++ b/src/main/java/CoCoNut_was/domains/user/service/UserService.java
@@ -30,9 +30,7 @@ public class UserService {
 
     // 1. 회원가입
     public void signUp(CreateUserDto dto) {
-        // 아이디 및 닉네임 중복확인 검증
-//        if(existsByEmail(dto.getEmail()) || existsByNickname(dto.getNickname()))
-//            throw new IllegalArgumentException("이메일 또는 닉네임이 중복되었습니다.");
+
         if(existsByEmail(dto.getEmail()))
             throw new CustomException(ErrorCode.EMAIL_ALREADY_EXIST);
         if(existsByNickname(dto.getNickname()))
@@ -110,14 +108,6 @@ public class UserService {
                 .build();
         res.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
-//        // . Access 토큰 임시 할당
-//        ResponseCookie accessCookie = ResponseCookie.from("accessToken", accessToken)
-//                .httpOnly(true)
-//                .path("/")
-//                .maxAge(60 * 60) // 한시간
-//                .build();
-//        res.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
-
         // 6. 기본 정보가 담긴 DTO 반환
         return TokenResDto.builder()
                 .accessToken(accessToken)
@@ -135,14 +125,7 @@ public class UserService {
                 .maxAge(0)
                 .build();
 
-//        ResponseCookie deleteAccessCookie = ResponseCookie.from("accessToken", "")
-//                .path("/")
-//                .httpOnly(true)
-//                .maxAge(0)
-//                .build();
-
         res.addHeader(HttpHeaders.SET_COOKIE, deleteRefreshCookie.toString());
-//        res.addHeader(HttpHeaders.SET_COOKIE, deleteAccessCookie.toString());
     }
 
     // 이메일을 통한 유저조회

--- a/src/main/java/CoCoNut_was/domains/user/service/UserService.java
+++ b/src/main/java/CoCoNut_was/domains/user/service/UserService.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,9 +63,9 @@ public class UserService {
 
     // 유저 삭제
     @Transactional
-    public void deleteUser(Long id) {
-        User user = userRepository.findById(id).orElseThrow(
-//                () -> new IllegalArgumentException("DB id : " + id + " 를 가진 유저가 존재하지 않습니다.")
+    public void deleteUser(UserDetails userDetails) {
+        User user = userRepository.findByEmail(userDetails.getUsername()).orElseThrow(
+    //                () -> new IllegalArgumentException("DB id : " + id + " 를 가진 유저가 존재하지 않습니다.")
                 () -> new CustomException(ErrorCode.USER_NOT_FOUND)
         );
         userRepository.delete(user);

--- a/src/main/java/CoCoNut_was/domains/user/service/UserService.java
+++ b/src/main/java/CoCoNut_was/domains/user/service/UserService.java
@@ -52,10 +52,17 @@ public class UserService {
         return userRepository.existsByNickname(nickname);
     }
 
-    // 유저 상세조회
-    public UserInfoDto getUser(Long id) {
-        User user = userRepository.findById(id).orElseThrow(
-//                () -> new IllegalArgumentException("DB id : " + id + " 를 가진 유저가 존재하지 않습니다.")
+    // 유저 상세조회 임시 폐기
+//    public UserInfoDto getUser(Long id) {
+//        User user = userRepository.findById(id).orElseThrow(
+//                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+//        );
+//        return UserInfoDto.fromEntity(user);
+//    }
+
+    // 마이페이지 상세 조회
+    public UserInfoDto me(UserDetails userDetails) {
+        User user = userRepository.findByEmail(userDetails.getUsername()).orElseThrow(
                 () -> new CustomException(ErrorCode.USER_NOT_FOUND)
         );
         return UserInfoDto.fromEntity(user);
@@ -65,7 +72,6 @@ public class UserService {
     @Transactional
     public void deleteUser(UserDetails userDetails) {
         User user = userRepository.findByEmail(userDetails.getUsername()).orElseThrow(
-    //                () -> new IllegalArgumentException("DB id : " + id + " 를 가진 유저가 존재하지 않습니다.")
                 () -> new CustomException(ErrorCode.USER_NOT_FOUND)
         );
         userRepository.delete(user);
@@ -145,4 +151,5 @@ public class UserService {
                 () -> new CustomException(ErrorCode.USER_NOT_FOUND)
         );
     }
+
 }

--- a/src/main/java/CoCoNut_was/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/CoCoNut_was/exception/CustomAuthenticationEntryPoint.java
@@ -21,7 +21,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
 
-        ErrorDto errorDto = new ErrorDto(HttpStatus.UNAUTHORIZED.value(), "액세스 토큰 인증이 필요합니다.");
+        ErrorDto errorDto = new ErrorDto(HttpStatus.UNAUTHORIZED.value(), "토큰이 없거나 만료되었습니다.");
 
         ObjectMapper objectMapper = new ObjectMapper();
         response.getWriter().write(objectMapper.writeValueAsString(errorDto));


### PR DESCRIPTION
## 작업 개요
- JWT 토큰 방식을 이용했음에도 불구하고 토큰을 통한 유저 조회를 사용하지 않은 치명적인 실수를 고쳤습니다.

## 변경 사항
- "회원 상세조회"를 "내 정보 조회"로 변경하였습니다.
- "내 정보 조회"와 "회원 탈퇴"는 토큰에서 추출한 유저의 정보 기반으로 조회하는 것으로 수정하였습니다.
- Swagger 명세에서 잘못 작성한 것이 여러번 식별되어 수정하였습니다.
- UserController, UserService 일부 메소드의 이름과 응답 형태를 변경하였습니다.
- 코드의 가독성을 저해하는 불필요한 주석을 삭제하였습니다.

## 관련 이슈
- 로그아웃 관련한 부분은 심사대상에서 중요한 부분이 아니니, 기본적인 로직은 구현해놓은 후 로그아웃 시 프론트엔드 분들이 클라이언트에서 토큰을 그냥 삭제시키는 방향으로 갈까 고민중입니다.