### PR TITLE
fix : CORS 허용 도메인에 localhost:5173 추가

### DIFF
--- a/src/main/java/CoCoNut_was/security/CorsConfig.java
+++ b/src/main/java/CoCoNut_was/security/CorsConfig.java
@@ -17,7 +17,7 @@ public class CorsConfig {
         CorsConfiguration configuration = new CorsConfiguration();
 
 //        configuration.addAllowedOriginPattern("*"); // 모든 출처 허용
-         configuration.setAllowedOrigins(List.of("http://example.com", "https://example.com")); // 특정 도메인만 허용
+         configuration.setAllowedOrigins(List.of("http://localhost:5173", "http://example.com", "https://example.com")); // 특정 도메인만 허용
 
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")); // 허용할 HTTP 메서드
         configuration.setAllowedHeaders(List.of("*")); // 모든 요청 헤더 허용


### PR DESCRIPTION
## 작업 개요
- CORS 허용 도메인에 localhost:5173 를 추가하는 작업을 진행하였습니다.

## 변경 사항
- CorsConfig.java 파일의 setAllowedOrigins에 http://localhost:5173를 추가하여 개발 서버의 요청을 허용하도록 수정했습니다.

## 관련 이슈
- 없음