### PR TITLE
fix : CORS 와일드카드로 모든 출처 허용

### DIFF
--- a/src/main/java/CoCoNut_was/security/CorsConfig.java
+++ b/src/main/java/CoCoNut_was/security/CorsConfig.java
@@ -16,8 +16,8 @@ public class CorsConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-//        configuration.addAllowedOriginPattern("*"); // 모든 출처 허용
-         configuration.setAllowedOrigins(List.of("http://localhost:5173", "http://example.com", "https://example.com")); // 특정 도메인만 허용
+        configuration.addAllowedOriginPattern("*"); // 모든 출처 허용
+//         configuration.setAllowedOrigins(List.of("http://localhost:5173", "http://example.com", "https://example.com")); // 특정 도메인만 허용
 
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")); // 허용할 HTTP 메서드
         configuration.setAllowedHeaders(List.of("*")); // 모든 요청 헤더 허용


### PR DESCRIPTION
## 작업 개요
-  CORS 와일드카드로 모든 출처를 허용하는 작업을 진행하였습니다.

## 변경 사항
- 프론트엔드 테스트를 위해서 CORS 와일드카드로 모든 출처 허용하였습니다.

## 관련 이슈
- #46 