### PR TITLE
Feature/submission swagger

### DIFF
--- a/src/main/java/CoCoNut_was/domains/project/controller/ProjectAiAssistanceApi.java
+++ b/src/main/java/CoCoNut_was/domains/project/controller/ProjectAiAssistanceApi.java
@@ -1,6 +1,7 @@
 package CoCoNut_was.domains.project.controller;
 
 import CoCoNut_was.domains.project.dto.ProjectAiAssistanceDto;
+import CoCoNut_was.domains.project.dto.ProjectPromptDto;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -13,7 +14,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import java.util.Map;
 
 @Tag(name = "Project AI Assistance API", description = "AI를 이용한 공모전 생성 지원 API")
 public interface ProjectAiAssistanceApi {
@@ -55,6 +55,6 @@ public interface ProjectAiAssistanceApi {
                                 "prompt": "대학생들을 타겟으로 하는 카페 로고 디자인 공모전을 열고 싶어"
                             }
                             """))
-            @RequestBody Map<String, String> userReq
+            @RequestBody ProjectPromptDto userReq
     ) throws JsonProcessingException;
 }

--- a/src/main/java/CoCoNut_was/domains/project/controller/ProjectAiAssistanceApi.java
+++ b/src/main/java/CoCoNut_was/domains/project/controller/ProjectAiAssistanceApi.java
@@ -25,7 +25,12 @@ public interface ProjectAiAssistanceApi {
                             schema = @Schema(implementation = ProjectAiAssistanceDto.class))),
             @ApiResponse(responseCode = "400", description = "잘못된 요청",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name = "프롬프트 누락", value = "프롬프트 내용이 없습니다."),
+                            @ExampleObject(name = "프롬프트 내용 없음" , value = """
+                                    {
+                                        "status": 400,
+                                        "message": "프롬프트 내용이 없습니다. 제대로 입력해주세요."
+                                    }
+                                    """),
                             @ExampleObject(name = "AI 생성 실패", value = """
                                     {
                                         "status": 400,

--- a/src/main/java/CoCoNut_was/domains/project/controller/ProjectAiAssistanceController.java
+++ b/src/main/java/CoCoNut_was/domains/project/controller/ProjectAiAssistanceController.java
@@ -1,6 +1,7 @@
 package CoCoNut_was.domains.project.controller;
 
 import CoCoNut_was.domains.project.dto.ProjectAiAssistanceDto;
+import CoCoNut_was.domains.project.dto.ProjectPromptDto;
 import CoCoNut_was.domains.project.service.ProjectAiAssistanceService;
 import CoCoNut_was.exception.CustomException;
 import CoCoNut_was.exception.ErrorCode;
@@ -24,9 +25,9 @@ public class ProjectAiAssistanceController implements ProjectAiAssistanceApi {
     @Override
     @PostMapping("/assist")
     public ResponseEntity<?> getAssistanceForProject(
-            @RequestBody Map<String, String> userReq
+            @RequestBody ProjectPromptDto userReq
     ) throws JsonProcessingException {
-        String userPrompt = userReq.get("prompt");
+        String userPrompt = userReq.getPrompt();
         if (userPrompt == null || userPrompt.isBlank())
             throw new CustomException(ErrorCode.PROMPT_IS_BLANK);
 

--- a/src/main/java/CoCoNut_was/domains/project/controller/ProjectAiAssistanceController.java
+++ b/src/main/java/CoCoNut_was/domains/project/controller/ProjectAiAssistanceController.java
@@ -2,6 +2,8 @@ package CoCoNut_was.domains.project.controller;
 
 import CoCoNut_was.domains.project.dto.ProjectAiAssistanceDto;
 import CoCoNut_was.domains.project.service.ProjectAiAssistanceService;
+import CoCoNut_was.exception.CustomException;
+import CoCoNut_was.exception.ErrorCode;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +28,7 @@ public class ProjectAiAssistanceController implements ProjectAiAssistanceApi {
     ) throws JsonProcessingException {
         String userPrompt = userReq.get("prompt");
         if (userPrompt == null || userPrompt.isBlank())
-            return ResponseEntity.badRequest().body("프롬프트 내용이 없습니다.");
+            throw new CustomException(ErrorCode.PROMPT_IS_BLANK);
 
         ProjectAiAssistanceDto result = projectAiAssistanceService.getAssistance(userPrompt);
         return ResponseEntity.ok(result);

--- a/src/main/java/CoCoNut_was/domains/project/dto/ProjectPromptDto.java
+++ b/src/main/java/CoCoNut_was/domains/project/dto/ProjectPromptDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 public class ProjectPromptDto {
-    @Schema(description = "AI에게 전달할 프롬프트 내용", example = "우리는 카페 아기사자의 메뉴판을 만들어주는 공모전에 지원했어. 아기사자의 밝은 갈색과 초원 색상을 잘 섞었어. 이러한 설명을 좀 자세히 적어줘")
+    @Schema(description = "AI에게 전달할 프롬프트 내용", example = "대학생들을 타겟으로 하는 카페 로고 디자인 공모전을 열고 싶어")
     @NotBlank(message = "프롬프트 내용은 비워둘 수 없습니다.")
     private String prompt;
 }

--- a/src/main/java/CoCoNut_was/domains/project/dto/ProjectPromptDto.java
+++ b/src/main/java/CoCoNut_was/domains/project/dto/ProjectPromptDto.java
@@ -1,0 +1,12 @@
+package CoCoNut_was.domains.project.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class ProjectPromptDto {
+    @Schema(description = "AI에게 전달할 프롬프트 내용", example = "우리는 카페 아기사자의 메뉴판을 만들어주는 공모전에 지원했어. 아기사자의 밝은 갈색과 초원 색상을 잘 섞었어. 이러한 설명을 좀 자세히 적어줘")
+    @NotBlank(message = "프롬프트 내용은 비워둘 수 없습니다.")
+    private String prompt;
+}

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionAiAssistanceApi.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionAiAssistanceApi.java
@@ -1,17 +1,58 @@
 package CoCoNut_was.domains.submission.controller;
 
+import CoCoNut_was.domains.submission.reqdto.SubmissionPromptDto;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import java.util.Map;
-
 @Tag(name = "SubmissionAiAssistance API", description = "공모전 작품설명 작성 도우미 AI API")
 public interface SubmissionAiAssistanceApi {
 
+    @Operation(summary = "작품설명 프롬프트", description = "작품설명 프롬프트 입력 시도")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "AI 응답 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "description": "아기사자 카페 메뉴판은 밝은 갈색과 초원 색상을 조화롭게 사용하여 따뜻하면서도 생동감 있는 디자인을 구현했습니다. 아기사자의 친근한 이미지를 살리고, 자연의 신선함을 담아 고객에게 편안한 분위기를 선사하는 메뉴판입니다."
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "프롬프트 정보 입력 오류",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "의도에 맞지않는 프롬프트 작성" , value = """
+                                    {
+                                        "status": 400,
+                                        "message": "AI Assistance 응답 생성에 실패하였습니다. 입력한 정보가 정확한지 확인해주세요"
+                                    }
+                                    """),
+                            @ExampleObject(name = "프롬프트 내용 없음" , value = """
+                                    {
+                                        "status": 400,
+                                        "message": "프롬프트 내용이 없습니다. 제대로 입력해주세요."
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status" : 401,
+                                        "message" : "토큰이 없거나 만료되었습니다."
+                                    }
+                                    """),
+                    }))
+    })
     ResponseEntity<?> getAssistanceForSubmission(
-            @RequestBody Map<String, String> userReq
+            @Parameter(description = "AI 프롬프트 입력")
+            @RequestBody SubmissionPromptDto userReq
     ) throws JsonProcessingException;
-    
+
 }

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionAiAssistanceApi.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionAiAssistanceApi.java
@@ -1,0 +1,17 @@
+package CoCoNut_was.domains.submission.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.Map;
+
+@Tag(name = "SubmissionAiAssistance API", description = "공모전 작품설명 작성 도우미 AI API")
+public interface SubmissionAiAssistanceApi {
+
+    ResponseEntity<?> getAssistanceForSubmission(
+            @RequestBody Map<String, String> userReq
+    ) throws JsonProcessingException;
+    
+}

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionAiAssistanceController.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionAiAssistanceController.java
@@ -15,7 +15,7 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/submissions")
-public class SubmissionAiAssistanceController {
+public class SubmissionAiAssistanceController implements SubmissionAiAssistanceApi {
 
     private final SubmissionAiAssistanceService submissionService;
 

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionAiAssistanceController.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionAiAssistanceController.java
@@ -2,6 +2,8 @@ package CoCoNut_was.domains.submission.controller;
 
 import CoCoNut_was.domains.submission.resdto.SubmissionAiAssistanceDto;
 import CoCoNut_was.domains.submission.service.SubmissionAiAssistanceService;
+import CoCoNut_was.exception.CustomException;
+import CoCoNut_was.exception.ErrorCode;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +27,7 @@ public class SubmissionAiAssistanceController implements SubmissionAiAssistanceA
     ) throws JsonProcessingException {
         String userPrompt = userReq.get("prompt");
         if (userPrompt == null || userPrompt.isBlank())
-            return ResponseEntity.badRequest().body("프롬프트 내용이 없습니다.");
+            throw new CustomException(ErrorCode.PROMPT_IS_BLANK);
 
         SubmissionAiAssistanceDto result = submissionService.getAssistance(userPrompt);
         return ResponseEntity.ok(result);

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionAiAssistanceController.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionAiAssistanceController.java
@@ -4,6 +4,7 @@ import CoCoNut_was.domains.submission.resdto.SubmissionAiAssistanceDto;
 import CoCoNut_was.domains.submission.service.SubmissionAiAssistanceService;
 import CoCoNut_was.exception.CustomException;
 import CoCoNut_was.exception.ErrorCode;
+import CoCoNut_was.domains.submission.reqdto.SubmissionPromptDto;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -11,8 +12,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,9 +22,9 @@ public class SubmissionAiAssistanceController implements SubmissionAiAssistanceA
 
     @PostMapping("/assist")
     public ResponseEntity<?> getAssistanceForSubmission(
-            @RequestBody Map<String, String> userReq
+            @RequestBody SubmissionPromptDto userReq
     ) throws JsonProcessingException {
-        String userPrompt = userReq.get("prompt");
+        String userPrompt = userReq.getPrompt();
         if (userPrompt == null || userPrompt.isBlank())
             throw new CustomException(ErrorCode.PROMPT_IS_BLANK);
 

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
@@ -1,0 +1,35 @@
+package CoCoNut_was.domains.submission.controller;
+
+import CoCoNut_was.domains.submission.reqdto.SubmitDto;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "Submission API", description = "공모전 작품 API")
+public interface SubmissionApi {
+
+
+    ResponseEntity<?> submit(
+            @PathVariable Long project_id,
+            @RequestPart("info") SubmitDto dto,
+            @RequestPart("image") MultipartFile image,
+            @AuthenticationPrincipal UserDetails userDetails
+    );
+
+
+
+    ResponseEntity<?> getSubmissions(@PathVariable Long project_id);
+
+
+
+    ResponseEntity<?> updateSubmission(
+            @PathVariable Long submission_id,
+            @RequestBody SubmitDto dto,
+            @AuthenticationPrincipal UserDetails userDetails
+    );
+}

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
@@ -1,7 +1,13 @@
 package CoCoNut_was.domains.submission.controller;
 
 import CoCoNut_was.domains.submission.reqdto.SubmitDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -13,11 +19,32 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "Submission API", description = "공모전 작품 API")
 public interface SubmissionApi {
 
-
+    @Operation(summary = "작품 제출", description = "작품 제출 시도")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "제출성공"),
+            @ApiResponse(responseCode = "400", description = "입력 누락 및 형식 비일치",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "작품 정보에 대한 누락 발생", value = """
+                                    {
+                                        "status": 400,
+                                        "message": "제출물 형태에 대해 누락이 있습니다. 반드시 KEY에 info를 포함하고, VALUE에 JSON값을, Content-Type를 application/json으로 설정해주세요."
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status" : 401,
+                                        "message" : "토큰이 없거나 만료되었습니다."
+                                    }
+                                    """),
+                    }))
+    })
     ResponseEntity<?> submit(
             @PathVariable Long project_id,
-            @RequestPart("info") SubmitDto dto,
-            @RequestPart("image") MultipartFile image,
+            @Valid @RequestPart(value = "info", required = true) SubmitDto dto,
+            @RequestPart(value = "image", required = false) MultipartFile image,
             @AuthenticationPrincipal UserDetails userDetails
     );
 

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
@@ -2,7 +2,6 @@ package CoCoNut_was.domains.submission.controller;
 
 import CoCoNut_was.domains.submission.reqdto.SubmitDto;
 import CoCoNut_was.domains.submission.resdto.SubmissionResDto;
-import CoCoNut_was.exception.ErrorDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -12,7 +11,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jdk.jfr.ContentType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -100,7 +98,28 @@ public interface SubmissionApi {
     ResponseEntity<?> getSubmissions(@PathVariable Long project_id);
 
 
-
+    @Operation(summary = "작품 수정", description = "작품 수정 시도")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status" : 401,
+                                        "message" : "토큰이 없거나 만료되었습니다."
+                                    }
+                                    """),
+                    })),
+            @ApiResponse(responseCode = "403", description = "로그인 정보와 작성자 정보 불일치",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 403,
+                                        "message": "작품의 유저정보와 로그인 정보가 일치하지 않습니다."
+                                    }
+                                    """),
+                    }))
+    })
     ResponseEntity<?> updateSubmission(
             @PathVariable Long submission_id,
             @RequestBody SubmitDto dto,

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
@@ -1,13 +1,18 @@
 package CoCoNut_was.domains.submission.controller;
 
 import CoCoNut_was.domains.submission.reqdto.SubmitDto;
+import CoCoNut_was.domains.submission.resdto.SubmissionResDto;
+import CoCoNut_was.exception.ErrorDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jdk.jfr.ContentType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -49,7 +54,49 @@ public interface SubmissionApi {
     );
 
 
-
+    @Operation(summary = "작품 목록 조회", description = "특정 공모전에 대한 모든 작품을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = SubmissionResDto.class)),
+                            examples = @ExampleObject(
+                                    name = "조회 성공 예시",
+                                    value = """
+                            [
+                                {
+                                    "title": "초콜릿 카페 메뉴판",
+                                    "description": "저희는 초콜릿을 직접 재배하여 판매합니다!",
+                                    "imageUrl": "https://storage.googleapis.com/coconut_bucket/chocolate_menu.jpeg"
+                                },
+                                {
+                                    "title": "여름 시즌 특별 음료 포스터",
+                                    "description": "시원한 여름을 위한 스페셜 에이드 출시!",
+                                    "imageUrl": "https://storage.googleapis.com/coconut_bucket/summer_ade_poster.png"
+                                }
+                            ]
+                            """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "해당 공모전을 찾을 수 없음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 404,
+                                        "message": "해당 공모전을 찾을 수 없습니다."
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status" : 401,
+                                        "message" : "토큰이 없거나 만료되었습니다."
+                                    }
+                                    """)
+                    }))
+    })
     ResponseEntity<?> getSubmissions(@PathVariable Long project_id);
 
 

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
@@ -3,6 +3,7 @@ package CoCoNut_was.domains.submission.controller;
 import CoCoNut_was.domains.submission.reqdto.SubmitDto;
 import CoCoNut_was.domains.submission.resdto.SubmissionResDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -45,8 +46,11 @@ public interface SubmissionApi {
                     }))
     })
     ResponseEntity<?> submit(
+            @Parameter(description = "프로젝트 고유 ID")
             @PathVariable Long project_id,
+            @Parameter(description = "작품 정보")
             @Valid @RequestPart(value = "info", required = true) SubmitDto dto,
+            @Parameter(description = "작품 대표 사진")
             @RequestPart(value = "image", required = false) MultipartFile image,
             @AuthenticationPrincipal UserDetails userDetails
     );
@@ -95,7 +99,10 @@ public interface SubmissionApi {
                                     """)
                     }))
     })
-    ResponseEntity<?> getSubmissions(@PathVariable Long project_id);
+    ResponseEntity<?> getSubmissions(
+            @Parameter(description = "프로젝트 고유 ID")
+            @PathVariable Long project_id
+    );
 
 
     @Operation(summary = "작품 수정", description = "작품 수정 시도")
@@ -121,8 +128,11 @@ public interface SubmissionApi {
                     }))
     })
     ResponseEntity<?> updateSubmission(
+            @Parameter(description = "프로젝트 고유 ID")
             @PathVariable Long submission_id,
+            @Parameter(description = "작품 수정 정보")
             @RequestBody SubmitDto dto,
+            @Parameter(description = "토큰 기반 유저 정보")
             @AuthenticationPrincipal UserDetails userDetails
     );
 }

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionController.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionController.java
@@ -57,5 +57,4 @@ public class SubmissionController implements SubmissionApi {
         return ResponseEntity.ok().build();
     }
 
-    // 4. 제출물 삭제 (미정)
 }

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionController.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionController.java
@@ -22,7 +22,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
-public class SubmissionController {
+public class SubmissionController implements SubmissionApi {
     private final SubmissionService submissionService;
 
 

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionController.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionController.java
@@ -3,6 +3,7 @@ package CoCoNut_was.domains.submission.controller;
 import CoCoNut_was.domains.submission.reqdto.SubmitDto;
 import CoCoNut_was.domains.submission.resdto.SubmissionResDto;
 import CoCoNut_was.domains.submission.service.SubmissionService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -30,8 +31,8 @@ public class SubmissionController implements SubmissionApi {
     @PostMapping("/projects/{project_id}/submissions")
     public ResponseEntity<?> submit(
             @PathVariable Long project_id,
-            @RequestPart("info") SubmitDto dto,
-            @RequestPart("image") MultipartFile image,
+            @Valid @RequestPart(value = "info", required = true) SubmitDto dto,
+            @RequestPart(value = "image", required = false) MultipartFile image,
             @AuthenticationPrincipal UserDetails userDetails
     ){
             submissionService.submit(project_id, dto, image, userDetails);

--- a/src/main/java/CoCoNut_was/domains/submission/reqdto/SubmissionPromptDto.java
+++ b/src/main/java/CoCoNut_was/domains/submission/reqdto/SubmissionPromptDto.java
@@ -1,0 +1,13 @@
+package CoCoNut_was.domains.submission.reqdto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class SubmissionPromptDto {
+
+    @Schema(description = "AI에게 전달할 프롬프트 내용", example = "우리는 카페 아기사자의 메뉴판을 만들어주는 공모전에 지원했어. 아기사자의 밝은 갈색과 초원 색상을 잘 섞었어. 이러한 설명을 좀 자세히 적어줘")
+    @NotBlank(message = "프롬프트 내용은 비워둘 수 없습니다.")
+    private String prompt;
+}

--- a/src/main/java/CoCoNut_was/domains/submission/reqdto/SubmitDto.java
+++ b/src/main/java/CoCoNut_was/domains/submission/reqdto/SubmitDto.java
@@ -3,6 +3,7 @@ package CoCoNut_was.domains.submission.reqdto;
 import CoCoNut_was.domains.project.entity.Project;
 import CoCoNut_was.domains.submission.entity.Submission;
 import CoCoNut_was.domains.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
@@ -11,9 +12,11 @@ import java.time.LocalDate;
 @Data
 public class SubmitDto {
 
+    @Schema(description = "공모전 작품 제목", example = "아기사자 디자인 브런치 카페 메뉴판")
     @NotBlank(message = "작품제목은 필수 입력입니다.")
     private String title;
 
+    @Schema(description = "공모전 작품 설명", example = "아기사자의 그림이 그려져있고, 아이들이 좋아할만한 캐릭터 디자인을 채택하였습니다.")
     private String description;
 
     // 제출 일자는 그냥 LocalDate.now()를 쓰면 되지 않을까 라는 생각입니다.

--- a/src/main/java/CoCoNut_was/exception/ErrorCode.java
+++ b/src/main/java/CoCoNut_was/exception/ErrorCode.java
@@ -24,7 +24,11 @@ public enum ErrorCode {
     SUBMISSION_USER_NOT_MATCHED(403, "작품의 유저정보와 로그인 정보가 일치하지 않습니다."),
     REQUIRED_SUBMISSION_INFO(400, "제출물 형태에 대해 누락이 있습니다. 반드시 KEY에 info를 포함하고, " +
             "VALUE에 JSON값을, Content-Type를 application/json으로 설정해주세요."),
-    IMAGE_UPLOAD_FAILED(500, "제출한 이미지 업로드에 예기치 않은 문제가 발생하였습니다.");
+    IMAGE_UPLOAD_FAILED(500, "제출한 이미지 업로드에 예기치 않은 문제가 발생하였습니다."),
+
+
+    // AI 관련
+    PROMPT_IS_BLANK(400, "프롬프트 내용이 없습니다. 제대로 입력해주세요.");
 
 
 

--- a/src/main/java/CoCoNut_was/exception/ErrorCode.java
+++ b/src/main/java/CoCoNut_was/exception/ErrorCode.java
@@ -22,8 +22,8 @@ public enum ErrorCode {
     // 공모전 제출물 관련
     SUBMISSION_NOT_FOUND(404, "해당 작품은 존재하지 않습니다."),
     SUBMISSION_USER_NOT_MATCHED(403, "작품의 유저정보와 로그인 정보가 일치하지 않습니다."),
-    REQUIRED_SUBMISSION_INFO(400, "작품 필수 제출물이 누락되었습니다."),
-    INVALID_MULTIPART_FORM(400, "작품의 멀티파트 제출 형식이 잘못되었거나, 요청 본문이 비어있습니다."),
+    REQUIRED_SUBMISSION_INFO(400, "제출물 형태에 대해 누락이 있습니다. 반드시 KEY에 info를 포함하고, " +
+            "VALUE에 JSON값을, Content-Type를 application/json으로 설정해주세요."),
     IMAGE_UPLOAD_FAILED(500, "제출한 이미지 업로드에 예기치 않은 문제가 발생하였습니다.");
 
 

--- a/src/main/java/CoCoNut_was/exception/ErrorCode.java
+++ b/src/main/java/CoCoNut_was/exception/ErrorCode.java
@@ -22,6 +22,8 @@ public enum ErrorCode {
     // 공모전 제출물 관련
     SUBMISSION_NOT_FOUND(404, "해당 작품은 존재하지 않습니다."),
     SUBMISSION_USER_NOT_MATCHED(403, "작품의 유저정보와 로그인 정보가 일치하지 않습니다."),
+    REQUIRED_SUBMISSION_INFO(400, "작품 필수 제출물이 누락되었습니다."),
+    INVALID_MULTIPART_FORM(400, "작품의 멀티파트 제출 형식이 잘못되었거나, 요청 본문이 비어있습니다."),
     IMAGE_UPLOAD_FAILED(500, "제출한 이미지 업로드에 예기치 않은 문제가 발생하였습니다.");
 
 

--- a/src/main/java/CoCoNut_was/exception/GlobalExceptionHandler.java
+++ b/src/main/java/CoCoNut_was/exception/GlobalExceptionHandler.java
@@ -9,6 +9,8 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MultipartException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,6 +42,23 @@ public class GlobalExceptionHandler {
         for(FieldError error : e.getBindingResult().getFieldErrors())
             errors.put(error.getField(), error.getDefaultMessage());
         return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+    }
+
+    // RequestPart에 대한 누락
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    protected ResponseEntity<?> handleMissingServletRequestPartException(MissingServletRequestPartException e) {
+        log.error("MissingServletRequestPartException", e);
+        ErrorDto errorDto = new ErrorDto(ErrorCode.REQUIRED_SUBMISSION_INFO.getStatus(), ErrorCode.REQUIRED_SUBMISSION_INFO.getMessage());
+        return new ResponseEntity<>(errorDto, HttpStatus.BAD_REQUEST);
+    }
+
+
+    // Multipart 요청의 형식이 잘못되었을 때 발생하는 예외
+    @ExceptionHandler(MultipartException.class)
+    protected ResponseEntity<?> handleMultipartException(MultipartException e) {
+        log.error("MultipartException", e);
+        ErrorDto errorDto = new ErrorDto(ErrorCode.INVALID_MULTIPART_FORM.getStatus(), ErrorCode.INVALID_MULTIPART_FORM.getMessage());
+        return new ResponseEntity<>(errorDto, HttpStatus.BAD_REQUEST);
     }
 
 }

--- a/src/main/java/CoCoNut_was/exception/GlobalExceptionHandler.java
+++ b/src/main/java/CoCoNut_was/exception/GlobalExceptionHandler.java
@@ -57,7 +57,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MultipartException.class)
     protected ResponseEntity<?> handleMultipartException(MultipartException e) {
         log.error("MultipartException", e);
-        ErrorDto errorDto = new ErrorDto(ErrorCode.INVALID_MULTIPART_FORM.getStatus(), ErrorCode.INVALID_MULTIPART_FORM.getMessage());
+        ErrorDto errorDto = new ErrorDto(ErrorCode.REQUIRED_SUBMISSION_INFO.getStatus(), ErrorCode.REQUIRED_SUBMISSION_INFO.getMessage());
         return new ResponseEntity<>(errorDto, HttpStatus.BAD_REQUEST);
     }
 


### PR DESCRIPTION
## 작업 개요
- Submission에 대한 API Swagger 명세를 완성하였습니다
- 그 외 Project와 Submission에 대한 Swagger와 로직의 수정이 있었습니다.

## 변경 사항
- Submission에 대한 모든 API를 명세하였습니다.
- 필요한 커스텀 예외처리를 추가하였습니다.
- 빈 프롬프트에 대한 에러 응답을 커스텀 예외처리 형태로 변환하였습니다.
- 프롬프트를 Map이 아닌 DTO로 별도로 담도록 수정하였습니다.

## 의견
- 수정하다보니 내용을 많이 수정한 것 같은데, 오류가 발생할 우려가 있으니 프론트엔드 분들도 Swagger 명세 오기입 부분을 체크해주시면 감사하겠습니다. @eastminnn 님의 Project 작업한 부분의 수정도 존재하여 확인 바랍니다.