### PR TITLE
fix : 공모전 조회 관련 securityFilterChain 수정

### DIFF
--- a/src/main/java/CoCoNut_was/security/SecurityConfig.java
+++ b/src/main/java/CoCoNut_was/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import CoCoNut_was.exception.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -50,6 +51,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/users/login").permitAll()
                         .requestMatchers("/api/v1/enums/businessTypes").permitAll()
                         .requestMatchers("/api/v1/enums/categories").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/projects").permitAll() // 공모전 목록 조회
+                        .requestMatchers(HttpMethod.GET, "/api/v1/projects/**").permitAll() // 공모전 상세 조회
                         .requestMatchers("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**",
                                 "/webjars/**", "/error").permitAll()
                         .anyRequest().authenticated()


### PR DESCRIPTION
## 작업 개요
- 공모전 조회 관련하여 securityFilterChain 을 수정하는 작업을 진행하였습니다.

## 변경 사항
- SecurityConfig 에서 공모전 목록과 상세 조회를 토큰없이 조회 가능하게 수정하였습니다.

## 관련 이슈
- #43 