### PR TITLE
feat : 회원가입 시 닉네임, 이메일 중복확인 API 추가

### DIFF
--- a/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
+++ b/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
@@ -16,6 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "User API", description = "유저 관련 API")
 public interface UserApi {
@@ -164,4 +165,41 @@ public interface UserApi {
     })
     ResponseEntity<?> logout(HttpServletResponse res);
 
+
+    @Operation(summary = "이메일 중복 확인", description = "사용 가능한 이메일인지 확인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용 가능한 이메일"),
+            @ApiResponse(responseCode = "409", description = "이미 사용 중인 이메일",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                {
+                                    "status" : 409,
+                                    "message" : "해당 이메일은 이미 존재합니다."
+                                }
+                                """)
+                    }))
+    })
+    ResponseEntity<?> checkEmail(
+            @Parameter(description = "확인할 이메일", required = true, example = "likelion13@gmail.com")
+            @RequestParam String email
+    );
+
+
+    @Operation(summary = "닉네임 중복 확인", description = "사용 가능한 닉네임인지 확인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용 가능한 닉네임"),
+            @ApiResponse(responseCode = "409", description = "이미 사용 중인 닉네임",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                {
+                                    "status" : 409,
+                                    "message" : "해당 닉네임은 이미 존재합니다."
+                                }
+                                """)
+                    }))
+    })
+    ResponseEntity<?> checkNickname(
+            @Parameter(description = "확인할 닉네임", required = true, example = "코코넛")
+            @RequestParam String nickname
+    );
 }

--- a/src/main/java/CoCoNut_was/domains/user/controller/UserController.java
+++ b/src/main/java/CoCoNut_was/domains/user/controller/UserController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -61,6 +62,22 @@ public class UserController implements UserApi {
     @PostMapping("/logout")
     public ResponseEntity<?> logout(HttpServletResponse res) {
         userService.logout(res);
+        return ResponseEntity.ok().build();
+    }
+
+    // 6. 이메일 중복 확인
+    @Override
+    @GetMapping("/check-email")
+    public ResponseEntity<?> checkEmail(@RequestParam String email) {
+        userService.checkEmailDuplication(email);
+        return ResponseEntity.ok().build();
+    }
+
+    // 7. 닉네임 중복 확인
+    @Override
+    @GetMapping("/check-nickname")
+    public ResponseEntity<?> checkNickname(@RequestParam String nickname) {
+        userService.checkNicknameDuplication(nickname);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/CoCoNut_was/domains/user/service/UserService.java
+++ b/src/main/java/CoCoNut_was/domains/user/service/UserService.java
@@ -135,4 +135,18 @@ public class UserService {
         );
     }
 
+    // 이메일 중복 시 예외 발생
+    public void checkEmailDuplication(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new CustomException(ErrorCode.EMAIL_ALREADY_EXIST);
+        }
+    }
+
+    // 닉네임 중복 시 예외 발생
+    public void checkNicknameDuplication(String nickname) {
+        if (userRepository.existsByNickname(nickname)) {
+            throw new CustomException(ErrorCode.NICKNAME_ALREADY_EXIST);
+        }
+    }
+
 }

--- a/src/main/java/CoCoNut_was/security/SecurityConfig.java
+++ b/src/main/java/CoCoNut_was/security/SecurityConfig.java
@@ -49,6 +49,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/users/sign-up").permitAll()
                         .requestMatchers("/api/v1/users/login").permitAll()
+                        .requestMatchers("/api/v1/users/check-email").permitAll()
+                        .requestMatchers("/api/v1/users/check-nickname").permitAll()
                         .requestMatchers("/api/v1/enums/businessTypes").permitAll()
                         .requestMatchers("/api/v1/enums/categories").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/projects").permitAll() // 공모전 목록 조회


### PR DESCRIPTION
## 작업 개요
- 회원가입 시 닉네임, 이메일 중복확인 API 를 추가하는 작업을 진행하였습니다.

## 변경 사항
- 닉네임과 중복확인을 할 수 있도록 API 를 추가하였습니다.

## 관련 이슈
- 없음