### PR TITLE
Feature/swagger, submission

### DIFF
--- a/src/main/java/CoCoNut_was/domains/project/entity/Project.java
+++ b/src/main/java/CoCoNut_was/domains/project/entity/Project.java
@@ -1,5 +1,6 @@
 package CoCoNut_was.domains.project.entity;
 
+import CoCoNut_was.domains.submission.entity.Submission;
 import CoCoNut_was.domains.user.entity.User;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -75,6 +76,9 @@ public class Project {
 
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProjectTarget> projectTargets = new ArrayList<>();
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Submission> submissions = new ArrayList<>();
 
     @PrePersist
     public void onCreate() { // 생성일자 자동 생성

--- a/src/main/java/CoCoNut_was/domains/project/service/ProjectService.java
+++ b/src/main/java/CoCoNut_was/domains/project/service/ProjectService.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class ProjectService {
     private final ProjectRepository projectRepository;
     private final ProjectColorRepository projectColorRepository;

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionAiAssistanceApi.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionAiAssistanceApi.java
@@ -12,10 +12,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name = "SubmissionAiAssistance API", description = "공모전 작품설명 작성 도우미 AI API")
+@Tag(name = "SubmissionAiAssistance API", description = "AI를 이용한 작품설명 작성 지원 API")
 public interface SubmissionAiAssistanceApi {
 
-    @Operation(summary = "작품설명 프롬프트", description = "작품설명 프롬프트 입력 시도")
+    @Operation(summary = "AI 작품 설명작성 지원", description = "사용자가 입력한 프롬프트를 기반으로 AI가 작품의 상세설명에 대해서 깔끔하게 작성해줍니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "AI 응답 성공",
                     content = @Content(mediaType = "application/json", examples = {

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
@@ -84,12 +84,10 @@ public interface SubmissionApi {
                             [
                                 {
                                     "title": "초콜릿 카페 메뉴판",
-                                    "description": "저희는 초콜릿을 직접 재배하여 판매합니다!",
                                     "imageUrl": "https://storage.googleapis.com/coconut_bucket/chocolate_menu.jpeg"
                                 },
                                 {
                                     "title": "여름 시즌 특별 음료 포스터",
-                                    "description": "시원한 여름을 위한 스페셜 에이드 출시!",
                                     "imageUrl": "https://storage.googleapis.com/coconut_bucket/summer_ade_poster.png"
                                 }
                             ]
@@ -106,15 +104,15 @@ public interface SubmissionApi {
                                     }
                                     """)
                     })),
-            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
-                    content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(value = """
-                                    {
-                                        "status" : 401,
-                                        "message" : "토큰이 없거나 만료되었습니다."
-                                    }
-                                    """)
-                    }))
+//            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
+//                    content = @Content(mediaType = "application/json", examples = {
+//                            @ExampleObject(value = """
+//                                    {
+//                                        "status" : 401,
+//                                        "message" : "토큰이 없거나 만료되었습니다."
+//                                    }
+//                                    """)
+//                    }))
     })
     ResponseEntity<?> getSubmissions(
             @Parameter(description = "프로젝트 고유 ID")

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
@@ -196,7 +196,51 @@ public interface SubmissionApi {
             @PathVariable Long submission_id,
             @Parameter(description = "작품 수정 정보")
             @RequestBody SubmitDto dto,
-            @Parameter(description = "토큰 기반 유저 정보")
+            @AuthenticationPrincipal UserDetails userDetails
+    );
+
+
+
+    @Operation(summary = "작품 제출 자격검증", description = "사용자가 이미 공모전에 작품을 제출했거나, 공모전 주인이 자신의 공모전에 참여해버리는 오류를 막기 위한 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "자격 있음"),
+            @ApiResponse(responseCode = "400", description = "입력 누락 및 형식 비일치",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "공모전 주인이 자신의 공모전에 신청하는 오류", value = """
+                                    {
+                                        "status": 400,
+                                        "message": "공모전 주인이 자신의 공모전에 지원할 수 없습니다."
+                                    }
+                                    """),
+                            @ExampleObject(name = "중복 지원 방지", value = """
+                                    {
+                                        "status": 400,
+                                        "message": "이미 지원하신 공모전에 다시 지원할 수 없습니다."
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status" : 401,
+                                        "message" : "토큰이 없거나 만료되었습니다."
+                                    }
+                                    """),
+                    })),
+            @ApiResponse(responseCode = "404", description = "해당 공모전을 찾을 수 없음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 404,
+                                        "message": "해당 공모전을 찾을 수 없습니다."
+                                    }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> checkSubmitValidation(
+            @Parameter(description = "작품 고유 ID")
+            @PathVariable Long project_id,
             @AuthenticationPrincipal UserDetails userDetails
     );
 }

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
@@ -140,10 +140,19 @@ public interface SubmissionApi {
                                         "message": "작품의 유저정보와 로그인 정보가 일치하지 않습니다."
                                     }
                                     """),
+                    })),
+            @ApiResponse(responseCode = "404", description = "해당 작품을 찾을 수 없음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 404,
+                                        "message": "해당 작품은 존재하지 않습니다."
+                                    }
+                                    """)
                     }))
     })
     ResponseEntity<?> updateSubmission(
-            @Parameter(description = "프로젝트 고유 ID")
+            @Parameter(description = "작품 고유 ID")
             @PathVariable Long submission_id,
             @Parameter(description = "작품 수정 정보")
             @RequestBody SubmitDto dto,

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
@@ -29,12 +29,12 @@ public interface SubmissionApi {
             @ApiResponse(responseCode = "200", description = "제출성공"),
             @ApiResponse(responseCode = "400", description = "입력 누락 및 형식 비일치",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name = "작품 정보에 대한 누락 발생", value = """
+                            @ExampleObject(name = "작품제목 누락", value = """
                                     {
                                         "title": "작품제목은 필수 입력입니다."
                                     }
                                     """),
-                            @ExampleObject(name = "작품 제목 누락", value = """
+                            @ExampleObject(name = "KEY 누락(소스코드 문제)", value = """
                                     {
                                         "status": 400,
                                         "message": "제출물 형태에 대해 누락이 있습니다. 반드시 KEY에 info를 포함하고, VALUE에 JSON값을, Content-Type를 application/json으로 설정해주세요."
@@ -49,6 +49,15 @@ public interface SubmissionApi {
                                         "message" : "토큰이 없거나 만료되었습니다."
                                     }
                                     """),
+                    })),
+            @ApiResponse(responseCode = "404", description = "해당 공모전을 찾을 수 없음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 404,
+                                        "message": "해당 공모전을 찾을 수 없습니다."
+                                    }
+                                    """)
                     }))
     })
     ResponseEntity<?> submit(

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
@@ -39,6 +39,12 @@ public interface SubmissionApi {
                                         "status": 400,
                                         "message": "제출물 형태에 대해 누락이 있습니다. 반드시 KEY에 info를 포함하고, VALUE에 JSON값을, Content-Type를 application/json으로 설정해주세요."
                                     }
+                                    """),
+                            @ExampleObject(name = "중복 지원 방지", value = """
+                                    {
+                                        "status": 400,
+                                        "message": "이미 지원하신 공모전에 다시 지원할 수 없습니다."
+                                    }
                                     """)
                     })),
             @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
@@ -21,10 +21,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
-@Tag(name = "Submission API", description = "공모전 작품 API")
+@Tag(name = "Submission API", description = "작품 관련 API")
 public interface SubmissionApi {
 
-    @Operation(summary = "작품 제출", description = "작품 제출 시도")
+    @Operation(summary = "작품 제출", description = "특정 공모전에 대한 작품을 제출합니다")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "제출성공"),
             @ApiResponse(responseCode = "400", description = "입력 누락 및 형식 비일치",
@@ -84,11 +84,11 @@ public interface SubmissionApi {
                             [
                                 {
                                     "title": "초콜릿 카페 메뉴판",
-                                    "imageUrl": "https://storage.googleapis.com/coconut_bucket/chocolate_menu.jpeg"
+                                    "imageUrl": "https://storage.googleapis.com/example_bucket/chocolate_menu.jpeg"
                                 },
                                 {
                                     "title": "여름 시즌 특별 음료 포스터",
-                                    "imageUrl": "https://storage.googleapis.com/coconut_bucket/summer_ade_poster.png"
+                                    "imageUrl": "https://storage.googleapis.com/example_bucket/summer_ade_poster.png"
                                 }
                             ]
                             """
@@ -117,6 +117,46 @@ public interface SubmissionApi {
     ResponseEntity<?> getSubmissions(
             @Parameter(description = "프로젝트 고유 ID")
             @PathVariable Long project_id
+    );
+
+    @Operation(summary = "작품 상세 조회", description = "특정 작품에 대한 상세 정보를 가져옵니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                      "title": "아기사자 디자인 브런치 카페 메뉴판",
+                                      "description": "아기사자의 그림이 그려져있고, 아이들이 좋아할만한 캐릭터 디자인을 채택하였습니다.",
+                                      "relatedUrl": "https://피그마주소.com",
+                                      "imageUrl": "https://storage.googleapis.com/example/123123.jpeg",
+                                      "submittedAt": "2025-08-14",
+                                      "writer": "열정있는 아기사자"
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status" : 401,
+                                        "message" : "토큰이 없거나 만료되었습니다."
+                                    }
+                                    """),
+                    })),
+            @ApiResponse(responseCode = "404", description = "해당 작품을 찾을 수 없음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                      "status": 404,
+                                      "message": "해당 작품은 존재하지 않습니다."
+                                    }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getSubmissionById(
+            @Parameter(description = "작품 고유 ID")
+            @PathVariable Long submission_id,
+            @AuthenticationPrincipal UserDetails userDetails
     );
 
 

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionController.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionController.java
@@ -25,7 +25,7 @@ public class SubmissionController implements SubmissionApi {
     private final SubmissionService submissionService;
 
 
-    // 1. 제출물 등록
+    // 1. 작품 등록
     @PostMapping(value = "/projects/{project_id}/submissions", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> submit(
             @PathVariable Long project_id,
@@ -37,13 +37,13 @@ public class SubmissionController implements SubmissionApi {
             return ResponseEntity.ok().build();
         }
 
-    // 2. 제출물 목록 조회(한 공모전에 대한 모든 제출물 조회)
+    // 2. 작품 목록 조회(한 공모전에 대한 모든 제출물 조회)
     @GetMapping("/projects/{project_id}/submissions")
     public ResponseEntity<?> getSubmissions(@PathVariable Long project_id){
         return ResponseEntity.ok().body(submissionService.getSubmissions(project_id));
     }
 
-    // 3. 제출물 단일 상세조회
+    // 3. 작품 단일 상세조회
     @GetMapping("/submissions/{submission_id}")
     public ResponseEntity<?> getSubmissionById(
             @PathVariable Long submission_id,
@@ -52,7 +52,7 @@ public class SubmissionController implements SubmissionApi {
         return ResponseEntity.ok().body(submissionService.getSubmissionDetails(submission_id, userDetails));
     }
 
-    // 4. 제출물 수정
+    // 4. 작품 수정
     @PutMapping("/submissions/{submission_id}")
     public ResponseEntity<?> updateSubmission(
             @PathVariable Long submission_id,
@@ -60,6 +60,17 @@ public class SubmissionController implements SubmissionApi {
             @AuthenticationPrincipal UserDetails userDetails
     ){
         submissionService.updateSubmission(submission_id, dto, userDetails);
+        return ResponseEntity.ok().build();
+    }
+
+
+    // 5. 작품 제출 자격확인
+    @GetMapping("/projects/{project_id}/submissions/valid")
+    public ResponseEntity<?> checkSubmitValidation(
+            @PathVariable Long project_id,
+            @AuthenticationPrincipal UserDetails userDetails
+    ){
+        submissionService.checkSubmitValidation(project_id, userDetails);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/CoCoNut_was/domains/submission/repository/SubmissionRepository.java
+++ b/src/main/java/CoCoNut_was/domains/submission/repository/SubmissionRepository.java
@@ -2,12 +2,18 @@ package CoCoNut_was.domains.submission.repository;
 
 import CoCoNut_was.domains.project.entity.Project;
 import CoCoNut_was.domains.submission.entity.Submission;
+import CoCoNut_was.domains.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SubmissionRepository extends JpaRepository<Submission, Long> {
     List<Submission> findByProject(Project project);
+
+    Optional<Submission> findByUser(User user);
+
+    boolean existsByUser(User user);
 }

--- a/src/main/java/CoCoNut_was/domains/submission/service/SubmissionService.java
+++ b/src/main/java/CoCoNut_was/domains/submission/service/SubmissionService.java
@@ -45,8 +45,11 @@ public class SubmissionService {
                 () -> new CustomException(ErrorCode.PROJECT_NOT_FOUND)
         );
 
+        // 3. 프로젝트 중복 참여 검사(접속 전 자격 검증을 했다면 일어나지 않을 예외, 방지용으로 추가)
+        if(submissionRepository.existsByUser(user))
+            throw new CustomException(ErrorCode.NOT_POSSIBLE_MORE_SUBMISSION);
 
-        // 3. 이미지 업로드
+        // 4. 이미지 업로드
         String imageUrl = null;
         try{
             if(image != null && !image.isEmpty())
@@ -55,10 +58,10 @@ public class SubmissionService {
             throw new CustomException(ErrorCode.IMAGE_UPLOAD_FAILED);
         }
 
-        // 4. Submission 엔티티 생성
+        // 5. Submission 엔티티 생성
         Submission submission = dto.toEntity(project, user, imageUrl);
 
-        // 5. 저장
+        // 6. 저장
         submissionRepository.save(submission);
 
     }

--- a/src/main/java/CoCoNut_was/domains/submission/service/SubmissionService.java
+++ b/src/main/java/CoCoNut_was/domains/submission/service/SubmissionService.java
@@ -13,6 +13,7 @@ import CoCoNut_was.exception.CustomException;
 import CoCoNut_was.exception.ErrorCode;
 import CoCoNut_was.gcs.ImageUploadService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +22,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SubmissionService {
@@ -120,5 +122,28 @@ public class SubmissionService {
             submission.setDescription(dto.getDescription());
 
         submissionRepository.save(submission);
+    }
+
+    public void checkSubmitValidation(Long projectId, UserDetails userDetails) {
+        // 0. 공모전 및 유저의 유효성 여부 검사
+        User user = userRepository.findByEmail(userDetails.getUsername()).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        Project project = projectRepository.findById(projectId).orElseThrow(
+                () -> new CustomException(ErrorCode.PROJECT_NOT_FOUND)
+        );
+
+        // 1. 공모전 주인이 자기 자신의 공모전에 지원하는 경우
+        if(project.getUser().getId().equals(user.getId()))
+            throw new CustomException(ErrorCode.BUSINESS_NOT_ALLOW_SELF_SUBMISSION);
+
+
+        // 2. 이미 해당 공모전에 지원한경우
+        if(submissionRepository.existsByUser(user))
+            throw new CustomException(ErrorCode.NOT_POSSIBLE_MORE_SUBMISSION);
+
+
+        // 해당 예외들을 모두 통과하면 지원자격이 있는 것
     }
 }

--- a/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
+++ b/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
@@ -133,6 +133,19 @@ public interface UserApi {
                                     }
                                     """)
                     })),
+            @ApiResponse(responseCode = "400", description = "입력 누락 및 형식 비일치",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "필드 누락", value = """
+                                    {
+                                        "<field>" : "<field>는 필수 입력입니다."
+                                    }
+                                    """),
+                            @ExampleObject(name = "이메일 형식 비일치", value = """
+                                    {
+                                        "email": "이메일 형식을 맞춰주세요."
+                                    }
+                                    """)
+                    })),
             @ApiResponse(responseCode = "401", description = "비밀번호 불일치",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """

--- a/src/main/java/CoCoNut_was/domains/user/entity/User.java
+++ b/src/main/java/CoCoNut_was/domains/user/entity/User.java
@@ -1,13 +1,20 @@
 package CoCoNut_was.domains.user.entity;
 
+import CoCoNut_was.domains.project.entity.Project;
+import CoCoNut_was.domains.submission.entity.Submission;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor
@@ -31,6 +38,12 @@ public class User{
 
     @Column(nullable = false)
     private Role role;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Project> projects = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Submission> submissions = new ArrayList<>();
 
     // 임시 빌더
     @Builder

--- a/src/main/java/CoCoNut_was/exception/ErrorCode.java
+++ b/src/main/java/CoCoNut_was/exception/ErrorCode.java
@@ -24,6 +24,8 @@ public enum ErrorCode {
     SUBMISSION_USER_NOT_MATCHED(403, "작품의 유저정보와 로그인 정보가 일치하지 않습니다."),
     REQUIRED_SUBMISSION_INFO(400, "작품 형태에 대해 누락이 있습니다. 반드시 KEY에 info를 포함하고, " +
             "VALUE에 JSON값을, Content-Type를 application/json으로 설정해주세요."),
+    BUSINESS_NOT_ALLOW_SELF_SUBMISSION(400,"공모전 주인이 자신의 공모전에 지원할 수 없습니다."),
+    NOT_POSSIBLE_MORE_SUBMISSION(400, "이미 지원하신 공모전에 다시 지원할 수 없습니다."),
     IMAGE_UPLOAD_FAILED(500, "제출한 이미지 업로드에 예기치 않은 문제가 발생하였습니다."),
 
 

--- a/src/main/java/CoCoNut_was/security/SecurityConfig.java
+++ b/src/main/java/CoCoNut_was/security/SecurityConfig.java
@@ -54,7 +54,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/enums/businessTypes").permitAll()
                         .requestMatchers("/api/v1/enums/categories").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/projects").permitAll() // 공모전 목록 조회
-                        .requestMatchers(HttpMethod.GET, "/api/v1/projects/**").permitAll() // 공모전 상세 조회
+                        .requestMatchers(HttpMethod.GET, "/api/v1/projects/{project_id}").permitAll() // 공모전 상세 조회
+                        .requestMatchers(HttpMethod.GET, "/api/v1/projects/{project_id}/submissions").permitAll()
                         .requestMatchers("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**",
                                 "/webjars/**", "/error").permitAll()
                         .anyRequest().authenticated()


### PR DESCRIPTION
## 작업 개요
- 전체적인 Swagger에 대한 검사와 그에 맞게 수정하거나 추가하는 작업을 하였습니다.
- 공모전 참여 작품제출 자격 검증 API를 추가하여 서비스의 안정성을 높였습니다.
- 엔티티 간의 연관 데이터들을 연쇄적으로 삭제할 수 있게 세팅하였습니다.

## 변경 사항
- Swagger에 대한 검증 후 수정
- 공모전 참여 작품제출 자격 검증 커스텀 예외 추가
- 공모전 참여 작품제출 자격 검증 API 구현
- 공모전 참여 작품제출 자격 검증 Swagger 작성
- 엔티티 간 생명주기 세팅
- 시큐리티 엔드포인트 구체화

## 의견
- 하다보니 변경사항이 많습니다. 코드 검증 면밀히 하고 승인 바랍니다.