### PR TITLE
Feature/role verification

### DIFF
--- a/src/main/java/CoCoNut_was/domains/project/controller/ProjectApi.java
+++ b/src/main/java/CoCoNut_was/domains/project/controller/ProjectApi.java
@@ -32,6 +32,12 @@ public interface ProjectApi {
                                         "title" : "제목은 필수 입력입니다."
                                     }
                                     """),
+                            @ExampleObject(name = "참가자 계정이 공모전 글을 작성하려고 하는 경우", value = """
+                                    {
+                                        "status": 400,
+                                        "message": "로그인된 계정이 해당 작업을 수행할 수 있는 역할이 아닙니다."
+                                    }
+                                    """)
                     })),
             @ApiResponse(responseCode = "401", description = "인증 실패 (토큰 없음 또는 만료)",
                     content = @Content(mediaType = "application/json", examples = {

--- a/src/main/java/CoCoNut_was/domains/project/controller/ProjectController.java
+++ b/src/main/java/CoCoNut_was/domains/project/controller/ProjectController.java
@@ -2,8 +2,11 @@ package CoCoNut_was.domains.project.controller;
 
 import CoCoNut_was.domains.project.dto.ProjectRequestDto;
 import CoCoNut_was.domains.project.service.ProjectService;
+import CoCoNut_was.domains.user.entity.Role;
 import CoCoNut_was.domains.user.entity.User;
 import CoCoNut_was.domains.user.service.UserService;
+import CoCoNut_was.exception.CustomException;
+import CoCoNut_was.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -33,6 +36,8 @@ public class ProjectController implements ProjectApi {
             @AuthenticationPrincipal UserDetails userDetails) {
 
         User currentUser = userService.findUserByEmail(userDetails.getUsername());
+        if(currentUser.getRole() != Role.ROLE_BUSINESS)
+            throw new CustomException(ErrorCode.WRITE_ROLE_NOT_MATCHED);
         Long projectId = projectService.createProject(dto, currentUser);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(projectId);

--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
@@ -45,6 +45,12 @@ public interface SubmissionApi {
                                         "status": 400,
                                         "message": "이미 지원하신 공모전에 다시 지원할 수 없습니다."
                                     }
+                                    """),
+                            @ExampleObject(name = "소상공인 계정이 공모전에 참여하려는 경우", value = """
+                                    {
+                                        "status": 400,
+                                        "message": "로그인된 계정이 해당 작업을 수행할 수 있는 역할이 아닙니다."
+                                    }
                                     """)
                     })),
             @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
@@ -212,10 +218,10 @@ public interface SubmissionApi {
             @ApiResponse(responseCode = "200", description = "자격 있음"),
             @ApiResponse(responseCode = "400", description = "입력 누락 및 형식 비일치",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name = "공모전 주인이 자신의 공모전에 신청하는 오류", value = """
+                            @ExampleObject(name = "소상공인 계정이 공모전에 참여하려는 경우", value = """
                                     {
                                         "status": 400,
-                                        "message": "공모전 주인이 자신의 공모전에 지원할 수 없습니다."
+                                        "message": "로그인된 계정이 해당 작업을 수행할 수 있는 역할이 아닙니다."
                                     }
                                     """),
                             @ExampleObject(name = "중복 지원 방지", value = """

--- a/src/main/java/CoCoNut_was/domains/submission/service/SubmissionService.java
+++ b/src/main/java/CoCoNut_was/domains/submission/service/SubmissionService.java
@@ -7,6 +7,7 @@ import CoCoNut_was.domains.submission.repository.SubmissionRepository;
 import CoCoNut_was.domains.submission.reqdto.SubmitDto;
 import CoCoNut_was.domains.submission.resdto.SubmissionDetailDto;
 import CoCoNut_was.domains.submission.resdto.SubmissionListDto;
+import CoCoNut_was.domains.user.entity.Role;
 import CoCoNut_was.domains.user.entity.User;
 import CoCoNut_was.domains.user.repository.UserRepository;
 import CoCoNut_was.exception.CustomException;
@@ -40,16 +41,20 @@ public class SubmissionService {
                 () -> new CustomException(ErrorCode.USER_NOT_FOUND)
         );
 
-        // 2. 프로젝트 존재 확인
+        // 2. 사용자 역할 검증
+        if(user.getRole() != Role.ROLE_USER)
+            throw new CustomException(ErrorCode.WRITE_ROLE_NOT_MATCHED);
+
+        // 3. 프로젝트 존재 확인
         Project project = projectRepository.findById(projectId).orElseThrow(
                 () -> new CustomException(ErrorCode.PROJECT_NOT_FOUND)
         );
 
-        // 3. 프로젝트 중복 참여 검사(접속 전 자격 검증을 했다면 일어나지 않을 예외, 방지용으로 추가)
+        // 4. 프로젝트 중복 참여 검사(접속 전 자격 검증을 했다면 일어나지 않을 예외, 방지용으로 추가)
         if(submissionRepository.existsByUser(user))
             throw new CustomException(ErrorCode.NOT_POSSIBLE_MORE_SUBMISSION);
 
-        // 4. 이미지 업로드
+        // 5. 이미지 업로드
         String imageUrl = null;
         try{
             if(image != null && !image.isEmpty())
@@ -58,10 +63,10 @@ public class SubmissionService {
             throw new CustomException(ErrorCode.IMAGE_UPLOAD_FAILED);
         }
 
-        // 5. Submission 엔티티 생성
+        // 6. Submission 엔티티 생성
         Submission submission = dto.toEntity(project, user, imageUrl);
 
-        // 6. 저장
+        // 7. 저장
         submissionRepository.save(submission);
 
     }
@@ -128,21 +133,22 @@ public class SubmissionService {
     }
 
     public void checkSubmitValidation(Long projectId, UserDetails userDetails) {
-        // 0. 공모전 및 유저의 유효성 여부 검사
+        // 1. 공모전 및 유저의 유효성 여부 검사
         User user = userRepository.findByEmail(userDetails.getUsername()).orElseThrow(
                 () -> new CustomException(ErrorCode.USER_NOT_FOUND)
         );
 
+        // 2. 사용자 역할 검증
+        if(user.getRole() != Role.ROLE_USER)
+            throw new CustomException(ErrorCode.WRITE_ROLE_NOT_MATCHED);
+
+
+        // 3. 프로젝트 존재 검사
         Project project = projectRepository.findById(projectId).orElseThrow(
                 () -> new CustomException(ErrorCode.PROJECT_NOT_FOUND)
         );
 
-        // 1. 공모전 주인이 자기 자신의 공모전에 지원하는 경우
-        if(project.getUser().getId().equals(user.getId()))
-            throw new CustomException(ErrorCode.BUSINESS_NOT_ALLOW_SELF_SUBMISSION);
-
-
-        // 2. 이미 해당 공모전에 지원한경우
+        // 4. 이미 해당 공모전에 지원한경우
         if(submissionRepository.existsByUser(user))
             throw new CustomException(ErrorCode.NOT_POSSIBLE_MORE_SUBMISSION);
 

--- a/src/main/java/CoCoNut_was/exception/ErrorCode.java
+++ b/src/main/java/CoCoNut_was/exception/ErrorCode.java
@@ -13,11 +13,10 @@ public enum ErrorCode {
     NICKNAME_ALREADY_EXIST(409, "해당 닉네임은 이미 존재합니다."),
     INCORRECT_PASSWORD(401, "비밀번호가 일치하지 않습니다."),
     INTERNAL_SERVER_ERROR(500, "내부 서버 오류입니다."),
+    WRITE_ROLE_NOT_MATCHED(400, "로그인된 계정이 해당 작업을 수행할 수 있는 역할이 아닙니다."),
 
     // 공모전 관련
     PROJECT_NOT_FOUND(404, "해당 공모전을 찾을 수 없습니다."),
-    AI_GENERATION_FAILED(400, "AI Assistance 응답 생성에 실패하였습니다. 입력한 정보가 정확한지 확인해주세요"),
-
 
     // 작품 관련
     SUBMISSION_NOT_FOUND(404, "해당 작품은 존재하지 않습니다."),
@@ -30,6 +29,7 @@ public enum ErrorCode {
 
 
     // AI 관련
+    AI_GENERATION_FAILED(400, "AI Assistance 응답 생성에 실패하였습니다. 입력한 정보가 정확한지 확인해주세요"),
     PROMPT_IS_BLANK(400, "프롬프트 내용이 없습니다. 제대로 입력해주세요.");
 
 

--- a/src/main/java/CoCoNut_was/exception/ErrorCode.java
+++ b/src/main/java/CoCoNut_was/exception/ErrorCode.java
@@ -23,7 +23,6 @@ public enum ErrorCode {
     SUBMISSION_USER_NOT_MATCHED(403, "작품의 유저정보와 로그인 정보가 일치하지 않습니다."),
     REQUIRED_SUBMISSION_INFO(400, "작품 형태에 대해 누락이 있습니다. 반드시 KEY에 info를 포함하고, " +
             "VALUE에 JSON값을, Content-Type를 application/json으로 설정해주세요."),
-    BUSINESS_NOT_ALLOW_SELF_SUBMISSION(400,"공모전 주인이 자신의 공모전에 지원할 수 없습니다."),
     NOT_POSSIBLE_MORE_SUBMISSION(400, "이미 지원하신 공모전에 다시 지원할 수 없습니다."),
     IMAGE_UPLOAD_FAILED(500, "제출한 이미지 업로드에 예기치 않은 문제가 발생하였습니다."),
 


### PR DESCRIPTION
## 작업 개요
- 서비스의 안정성을 위해 공모전은 소상공인만, 작품은 참가자들만 작성할 수 있게 예외 응답을 추가하였습니다.

## 변경 사항
- Project 등록 시 참가자 역할을 가진 사용자가 접근하지 못하게 하였습니다.
- Submission 제출 시 소상공인 역할을 가진 사용자가 접근하지 못하게 하였습니다.
- Submission 제출 자격검증 메소드에 있던 예외를 이번에 새로 만든 로직으로 교체하였습니다.