### PR TITLE
Feature/submission edit

### DIFF
--- a/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
+++ b/src/main/java/CoCoNut_was/domains/submission/controller/SubmissionApi.java
@@ -95,10 +95,16 @@ public interface SubmissionApi {
                                     value = """
                             [
                                 {
+                                    "submissionId": 123,
+                                    "projectId": 12,
+                                    "userId": 1,
                                     "title": "초콜릿 카페 메뉴판",
                                     "imageUrl": "https://storage.googleapis.com/example_bucket/chocolate_menu.jpeg"
                                 },
                                 {
+                                    "submissionId": 124,
+                                    "projectId": 12,
+                                    "userId": 2,
                                     "title": "여름 시즌 특별 음료 포스터",
                                     "imageUrl": "https://storage.googleapis.com/example_bucket/summer_ade_poster.png"
                                 }
@@ -137,12 +143,15 @@ public interface SubmissionApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                     {
-                                      "title": "아기사자 디자인 브런치 카페 메뉴판",
-                                      "description": "아기사자의 그림이 그려져있고, 아이들이 좋아할만한 캐릭터 디자인을 채택하였습니다.",
-                                      "relatedUrl": "https://피그마주소.com",
-                                      "imageUrl": "https://storage.googleapis.com/example/123123.jpeg",
-                                      "submittedAt": "2025-08-14",
-                                      "writer": "열정있는 아기사자"
+                                        "submissionId": 123,
+                                        "projectId": 12,
+                                        "userId": 1,
+                                        "title": "초콜릿 카페",
+                                        "description": "저희는 초콜릿을 직접 재배하여 판매합니다!",
+                                        "relatedUrl": https://github.com/java_spring_lover/chocolate_farmer,
+                                        "imageUrl": https://storage.googleapis.com/example_bucket/chocolate_menu.jpeg,
+                                        "submittedAt": "2025-08-15",
+                                        "writer": "자바칩프라푸치노"
                                     }
                                     """)
                     })),

--- a/src/main/java/CoCoNut_was/domains/submission/resdto/SubmissionDetailDto.java
+++ b/src/main/java/CoCoNut_was/domains/submission/resdto/SubmissionDetailDto.java
@@ -8,6 +8,14 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class SubmissionDetailDto {
+    // 작품 ID
+    private Long submissionId;
+
+    // 공모전 ID
+    private Long projectId;
+
+    // 작성자 ID
+    private Long userId;
 
     // 작품명
     private String title;
@@ -27,7 +35,10 @@ public class SubmissionDetailDto {
     // 작성자(제출팀 대표자)
     private String writer;
 
-    @Builder public SubmissionDetailDto(String title, String description, String relatedUrl, String imageUrl, String submittedAt, String writer) {
+    @Builder public SubmissionDetailDto(Long submissionId, Long projectId, Long userId, String title, String description, String relatedUrl, String imageUrl, String submittedAt, String writer) {
+        this.submissionId = submissionId;
+        this.projectId = projectId;
+        this.userId = userId;
         this.title = title;
         this.description = description;
         this.relatedUrl = relatedUrl;
@@ -38,6 +49,9 @@ public class SubmissionDetailDto {
 
     public static SubmissionDetailDto fromEntity(Submission submission) {
         return SubmissionDetailDto.builder()
+                .submissionId(submission.getId())
+                .projectId(submission.getProject().getId())
+                .userId(submission.getUser().getId())
                 .title(submission.getTitle())
                 .description(submission.getDescription())
                 .relatedUrl(submission.getRelatedUrl())

--- a/src/main/java/CoCoNut_was/domains/submission/resdto/SubmissionListDto.java
+++ b/src/main/java/CoCoNut_was/domains/submission/resdto/SubmissionListDto.java
@@ -8,16 +8,30 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class SubmissionListDto {
+
+    private Long submissionId;
+
+    private Long projectId;
+
+    private Long userId;
+
     private String title;
+
     private String imageUrl;
 
-    @Builder public SubmissionListDto(String title, String imageUrl) {
+    @Builder public SubmissionListDto(Long submissionId, Long projectId, Long userId, String title, String imageUrl) {
+        this.submissionId = submissionId;
+        this.projectId = projectId;
+        this.userId = userId;
         this.title = title;
         this.imageUrl = imageUrl;
     }
 
     public static SubmissionListDto fromEntity(Submission submission) {
         return SubmissionListDto.builder()
+                .submissionId(submission.getId())
+                .projectId(submission.getProject().getId())
+                .userId(submission.getUser().getId())
                 .title(submission.getTitle())
                 .imageUrl(submission.getImageUrl())
                 .build();

--- a/src/main/java/CoCoNut_was/domains/submission/service/SubmissionService.java
+++ b/src/main/java/CoCoNut_was/domains/submission/service/SubmissionService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -128,6 +129,8 @@ public class SubmissionService {
             submission.setTitle(dto.getTitle());
         if(dto.getDescription() != null && !dto.getDescription().isBlank())
             submission.setDescription(dto.getDescription());
+
+        submission.setSubmittedAt(LocalDate.now());
 
         submissionRepository.save(submission);
     }

--- a/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
+++ b/src/main/java/CoCoNut_was/domains/user/controller/UserApi.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Tag(name = "User API", description = "유저 관련 API")
 public interface UserApi {
 
-    @Operation(summary = "회원가입", description = "회원가입 시도")
+    @Operation(summary = "회원가입", description = "서비스를 이용하기 위한 회원가입 입니다. role은 ROLE_USER, ROLE_BUSINESS 둘중 하나만 가능합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "회원가입 성공"),
             @ApiResponse(responseCode = "400", description = "입력 누락 및 형식 비일치",
@@ -64,12 +64,13 @@ public interface UserApi {
     );
 
 
-    @Operation(summary = "내 정보 조회", description = "조회 시도")
+    @Operation(summary = "내 정보 조회", description = "자신의 정보를 조회하는 기능입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                     {
+                                        "user_id": "<user_id>",
                                         "email": "<email>",
                                         "name": "<name>",
                                         "nickname": "<nickname>",
@@ -93,7 +94,7 @@ public interface UserApi {
     );
 
 
-    @Operation(summary = "회원탈퇴(삭제)", description = "탈퇴(삭제) 시도")
+    @Operation(summary = "회원탈퇴(삭제)", description = "회원탈퇴를 하는 기능입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "삭제 성공"),
             @ApiResponse(responseCode = "401", description = "인증 실패",
@@ -112,7 +113,7 @@ public interface UserApi {
     );
 
 
-    @Operation(summary = "로그인", description = "로그인 시도")
+    @Operation(summary = "로그인", description = "로그인을 하는 기능이며, 여기서 나온 토큰으로 서비스에서 유저 정보를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그인 성공",
                     content = @Content(mediaType = "application/json", examples = {
@@ -163,7 +164,7 @@ public interface UserApi {
     );
 
 
-    @Operation(summary = "로그아웃", description = "로그아웃 시도")
+    @Operation(summary = "로그아웃", description = "로그아웃을 하는 기능입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
             @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",

--- a/src/main/java/CoCoNut_was/domains/user/resdto/UserInfoDto.java
+++ b/src/main/java/CoCoNut_was/domains/user/resdto/UserInfoDto.java
@@ -6,12 +6,14 @@ import lombok.Data;
 
 @Data
 public class UserInfoDto {
+    private Long user_id;
     private String email;
     private String name;
     private String nickname;
     private String role;
 
-    @Builder public UserInfoDto(String email, String name, String nickname, String role) {
+    @Builder public UserInfoDto(Long user_id, String email, String name, String nickname, String role) {
+        this.user_id = user_id;
         this.email = email;
         this.name = name;
         this.nickname = nickname;
@@ -20,6 +22,7 @@ public class UserInfoDto {
 
     public static UserInfoDto fromEntity(User user){
         return UserInfoDto.builder()
+                .user_id(user.getId())
                 .email(user.getEmail())
                 .name(user.getName())
                 .nickname(user.getNickname())


### PR DESCRIPTION
## 작업 개요
- 수정 시 작성일도 당일로 최신화 해주는 기능을 추가하였습니다.
- Submission 조회 관련하여 PK와 FK정보가 존재하지 않아 모두 추가하였습니다.
- User 조회에서도 PK 정보를 추가하였습니다.

## 변경 사항
- 작품 수정에서 작성일을 당일로 최신화 해주는 기능 추가
- Submission 응답 DTO에 submission_id, project_id, user_id를 모두 반환하도록 추가
- User 조회 응답 DTO에 user_id를 반환하도록 추가
- DTO 변경사항에 대응하여 Swagger 명세 최신화
- User API 관련 명세 설명 구체화

## 의견
- 프론트엔드에서 필요한 필드 혹은 필요없는 필드들을 선별해서 저희가 지속적으로 수정할 필요가 있어보입니다.