### PR TITLE
fix : 공모전 상세조회 DTO  수정

### DIFF
--- a/src/main/java/CoCoNut_was/domains/project/dto/ProjectDetailResponseDto.java
+++ b/src/main/java/CoCoNut_was/domains/project/dto/ProjectDetailResponseDto.java
@@ -29,6 +29,7 @@ public class ProjectDetailResponseDto { // 공모전 상세 조회 DTO (응답)
     private final int rewardAmount;
     private final String summary;
     private final Status status;
+    private final String imageUrl;
     private final List<String> colors;
     private final List<String> styles;
     private final List<String> targets;
@@ -48,6 +49,7 @@ public class ProjectDetailResponseDto { // 공모전 상세 조회 DTO (응답)
                 .rewardAmount(project.getRewardAmount())
                 .summary(project.getSummary())
                 .status(project.getStatus())
+                .imageUrl(project.getImageUrl())
                 .colors(project.getProjectColors().stream()
                         .map(ProjectColor::getColor)
                         .collect(Collectors.toList()))


### PR DESCRIPTION
## 작업 개요
- 공모전 상세조회 DTO 를 수정하는 작업을 진행하였습니다.

## 변경 사항
- 공모전 상세조회에 이미지 링크를 추가하였습니다.

## 관련 이슈
- 없음