### PR TITLE
fix : 작품이 단 한번만 제출 가능했던 문제 해결

### DIFF
--- a/src/main/java/CoCoNut_was/domains/submission/repository/SubmissionRepository.java
+++ b/src/main/java/CoCoNut_was/domains/submission/repository/SubmissionRepository.java
@@ -1,5 +1,6 @@
 package CoCoNut_was.domains.submission.repository;
 
+import CoCoNut_was.domains.project.entity.Project;
 import CoCoNut_was.domains.submission.entity.Submission;
 import CoCoNut_was.domains.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,7 +13,7 @@ import java.util.Optional;
 public interface SubmissionRepository extends JpaRepository<Submission, Long> {
     Optional<Submission> findByUser(User user);
 
-    boolean existsByUser(User user);
-
     List<Submission> findByProjectId(Long project_id);
+
+    boolean existsByUserAndProject(User user, Project project);
 }

--- a/src/main/java/CoCoNut_was/domains/submission/service/SubmissionService.java
+++ b/src/main/java/CoCoNut_was/domains/submission/service/SubmissionService.java
@@ -52,7 +52,7 @@ public class SubmissionService {
         );
 
         // 4. 프로젝트 중복 참여 검사(접속 전 자격 검증을 했다면 일어나지 않을 예외, 방지용으로 추가)
-        if(submissionRepository.existsByUser(user))
+        if(submissionRepository.existsByUserAndProject(user, project))
             throw new CustomException(ErrorCode.NOT_POSSIBLE_MORE_SUBMISSION);
 
         // 5. 이미지 업로드
@@ -155,7 +155,7 @@ public class SubmissionService {
         );
 
         // 4. 이미 해당 공모전에 지원한경우
-        if(submissionRepository.existsByUser(user))
+        if(submissionRepository.existsByUserAndProject(user, project))
             throw new CustomException(ErrorCode.NOT_POSSIBLE_MORE_SUBMISSION);
 
 


### PR DESCRIPTION
## 작업 개요
- 프론트엔드 요청에서 계정당 모든 공모전에서 그냥 단 한번만 작품 제출이 가능했던 버그가 발견되어 수정하였습니다.

## 변경 사항
- SubmissionRepository에 있던 existsByUser를 existsByUserAndProject로 수정하였습니다.