### PR TITLE
fix : 공모전 상세조회 토큰 필요

### DIFF
--- a/src/main/java/CoCoNut_was/security/SecurityConfig.java
+++ b/src/main/java/CoCoNut_was/security/SecurityConfig.java
@@ -54,7 +54,6 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/enums/businessTypes").permitAll()
                         .requestMatchers("/api/v1/enums/categories").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/projects").permitAll() // 공모전 목록 조회
-                        .requestMatchers(HttpMethod.GET, "/api/v1/projects/{project_id}").permitAll() // 공모전 상세 조회
                         .requestMatchers(HttpMethod.GET, "/api/v1/projects/{project_id}/submissions").permitAll()
                         .requestMatchers("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**",
                                 "/webjars/**", "/error").permitAll()


### PR DESCRIPTION
## 작업 개요
- 엑세스 토큰이 있어야지 공모전 상세조회를 할 수 있도록 작업을 진행하였습니다.

## 변경 사항
- SecurityConfig 에서 공모전 상세조회 코드를 제거하였습니다.

## 관련 이슈
- 없음