### PR TITLE
fix : 공모전 제목 길이 제한 추가

### DIFF
--- a/src/main/java/CoCoNut_was/domains/project/entity/Project.java
+++ b/src/main/java/CoCoNut_was/domains/project/entity/Project.java
@@ -35,7 +35,7 @@ public class Project {
     @JoinColumn(name = "user_id", nullable = false)
     private User user; // 사용자와 N:1
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 50)
     private String title; // 공모전 제목
 
     @Column(nullable = false)


### PR DESCRIPTION
## 작업 개요
- 공모전 제목 길이 제한 추가하는 작업을 진행하였습니다.

## 변경 사항
- 제목이 50자가 넘어가면 공모전 리스트가 깨지는 현상이 발생해 수정하였습니다.

## 관련 이슈
- 없음