### PR TITLE
fix : 투표 N+1 문제 해결

### DIFF
--- a/src/main/java/CoCoNut_was/domains/submission/repository/SubmissionRepository.java
+++ b/src/main/java/CoCoNut_was/domains/submission/repository/SubmissionRepository.java
@@ -4,6 +4,8 @@ import CoCoNut_was.domains.project.entity.Project;
 import CoCoNut_was.domains.submission.entity.Submission;
 import CoCoNut_was.domains.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -18,4 +20,7 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
     List<Submission> findByUserId(Long id);
 
     long countByProjectId(Long projectId);
+
+    @Query("SELECT s FROM Submission s JOIN FETCH s.user WHERE s.project.id = :projectId")
+    List<Submission> findByProjectIdWithUser(@Param("projectId") Long projectId);
 }

--- a/src/main/java/CoCoNut_was/domains/vote/service/VoteService.java
+++ b/src/main/java/CoCoNut_was/domains/vote/service/VoteService.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -86,22 +87,18 @@ public class VoteService {
                 () -> new CustomException(ErrorCode.PROJECT_NOT_FOUND)
         );
 
-        List<Submission> submissions = submissionRepository.findByProjectId(project.getId());
-        List<VoteResultDto> results = new ArrayList<>();
+        List<Submission> submissions = submissionRepository.findByProjectIdWithUser(project.getId());
 
-        for (Submission submission : submissions) {
-            results.add(VoteResultDto.builder()
-                            .submissionId(submission.getId())
-                            .projectId(submission.getProject().getId())
-                            .voteStartTime(project.getDeadline().plusDays(1).toString())
-                            .voteDeadline(project.getDeadline().plusDays(7).toString())
-                            .title(submission.getTitle())
-                            .imageUrl(submission.getImageUrl())
-                            .voteCount(voteRepository.countBySubmissionId(submission.getId()))
-                            .build()
-            );
-        }
-
-        return results;
+        return submissions.stream()
+                .map(submission -> VoteResultDto.builder()
+                        .submissionId(submission.getId())
+                        .projectId(submission.getProject().getId())
+                        .voteStartTime(project.getDeadline().plusDays(1).toString())
+                        .voteDeadline(project.getDeadline().plusDays(7).toString())
+                        .title(submission.getTitle())
+                        .imageUrl(submission.getImageUrl())
+                        .voteCount((long) submission.getVotes().size())
+                        .build())
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 작업 개요
-  투표 N+1 문제를 해결하는 작업을 진행하였습니다.

## 변경 사항
- 특정 공모전에 제출된 모든 작품 목록을 가져옵니다. (쿼리 1번)
- 그 후, 각 작품마다 몇 개의 투표를 받았는지 알아내기 위해 voteRepository.countBySubmissionId()를 호출합니다. 이 과정에서 작품 개수(N개)만큼 추가 쿼리가 발생하는 문제를 해결했습니다.

## 관련 이슈
- https://zamezzz.tistory.com/entry/JPA%EC%9D%98-N1-%EB%AC%B8%EC%A0%9C-%EC%99%9C-%EC%83%9D%EA%B8%B0%EA%B3%A0-%EC%96%B4%EB%96%BB%EA%B2%8C-%ED%95%B4%EA%B2%B0%ED%95%A0%EA%B9%8C