### PR TITLE
fix : 공모전 수상정보 보안해제

### DIFF
--- a/src/main/java/CoCoNut_was/security/SecurityConfig.java
+++ b/src/main/java/CoCoNut_was/security/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/users/check-nickname").permitAll()
                         .requestMatchers("/api/v1/enums/businessTypes").permitAll()
                         .requestMatchers("/api/v1/enums/categories").permitAll()
+                        .requestMatchers("/api/v1/winner/project/{project_id}").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/projects").permitAll() // 공모전 목록 조회
                         .requestMatchers(HttpMethod.GET, "/api/v1/projects/{project_id}/submissions").permitAll()
                         .requestMatchers("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**",


### PR DESCRIPTION
## 작업 개요
- 프론트엔드 게스트 페이지에서 우수작 이미지가 보이지 않는 문제로 공모전 수상정보 Security를 모두 허용하였습니다.